### PR TITLE
Implement thermostat capabilities (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added capability functions for thermostat devices:
+  * `getCoolingSetpoint` and `setCoolingSetpoint`
+  * `getHeatingSetpoint` and `setHeatingSetpoint`
+  * `getThermostatSchedule` and `setThermostatSchedule`
+  * `getSupportedThermostatFanModes`
+  * `getSupportedThermostatModes`
+  * `getThermostatFanMode` and `setThermostatFanMode`
+  * `getThermostatMode` and `setThermostatMode`
+  * `getThermostatOperatingState`
+  * `getThermostatSetpoint` and `setThermostatSetpoint`
+- Added capability functions for virtual thermostat devices:
+  * `setSupportedThermostatFanModes`
+  * `setSupportedThermostatModes`
+  * `setThermostatOperatingState`
+- Added capability function for virtual temperature sensor devices: `setTemperature`.
+- Added capability-related helper function `enumListToStringList`.
+  
+
 ## [0.1.0-beta.5] - 2020-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `setThermostatOperatingState`
 - Added capability function for virtual temperature sensor devices: `setTemperature`.
 - Added capability-related helper function `enumListToStringList`.
-  
 
 ## [0.1.0-beta.5] - 2020-08-26
 

--- a/src/hubitat-capabilities/capabilities-helpers.spec.ts
+++ b/src/hubitat-capabilities/capabilities-helpers.spec.ts
@@ -1,0 +1,47 @@
+import { enumListToStringList } from './capabilities.helpers';
+
+describe('capabilities-helpers', () => {
+
+  describe('enumListToStringList', () => {
+
+    it('should return empty list for empty string', () => {
+      expect(enumListToStringList('')).toEqual([]);
+    });
+
+    it('should return empty list for missing surrounding brackets', () => {
+      expect(enumListToStringList('[value, value3, aaald')).toEqual([]);
+      expect(enumListToStringList('something, and yet, something else')).toEqual([]);
+      expect(enumListToStringList('ddwda2, 2254d, 99kd]')).toEqual([]);
+      expect(enumListToStringList('[')).toEqual([]);
+      expect(enumListToStringList(']')).toEqual([]);
+    });
+
+    it('should return empty list for string with no values', () => {
+      expect(enumListToStringList('[]')).toEqual([]);
+      expect(enumListToStringList('[ ]')).toEqual([]);
+      expect(enumListToStringList('[     ]')).toEqual([]);
+      expect(enumListToStringList('[,]')).toEqual([]);
+      expect(enumListToStringList('[ , ]')).toEqual([]);
+      expect(enumListToStringList('[, ,    ,,]')).toEqual([]);
+      expect(enumListToStringList('[,,,,,,,,,,]')).toEqual([]);
+    });
+
+    it('should skip empty values', () => {
+      expect(enumListToStringList('[hello,,world]'))
+        .toEqual(['hello', 'world']);
+      expect(enumListToStringList('[,, ,how are you? ]'))
+        .toEqual(['how are you?']);
+      expect(enumListToStringList('[ , HubHazard , , Hubitat]'))
+        .toEqual(['HubHazard', 'Hubitat']);
+    });
+
+    it('should return a valid list of values', () => {
+      expect(enumListToStringList('[auto, on, heat, cool]'))
+        .toEqual(['auto', 'on', 'heat', 'cool']);
+      expect(enumListToStringList('[a, a, a , a,a,a ]'))
+        .toEqual(['a', 'a', 'a', 'a', 'a', 'a']);
+      expect(enumListToStringList('[get up, get down, get off, get on, get by, get, get set]'))
+        .toEqual(['get up', 'get down', 'get off', 'get on', 'get by', 'get', 'get set']);
+    });
+  });
+});

--- a/src/hubitat-capabilities/capabilities-helpers.spec.ts
+++ b/src/hubitat-capabilities/capabilities-helpers.spec.ts
@@ -1,9 +1,7 @@
 import { enumListToStringList } from './capabilities.helpers';
 
 describe('capabilities-helpers', () => {
-
   describe('enumListToStringList', () => {
-
     it('should return empty list for empty string', () => {
       expect(enumListToStringList('')).toEqual([]);
     });
@@ -27,21 +25,23 @@ describe('capabilities-helpers', () => {
     });
 
     it('should skip empty values', () => {
-      expect(enumListToStringList('[hello,,world]'))
-        .toEqual(['hello', 'world']);
-      expect(enumListToStringList('[,, ,how are you? ]'))
-        .toEqual(['how are you?']);
-      expect(enumListToStringList('[ , HubHazard , , Hubitat]'))
-        .toEqual(['HubHazard', 'Hubitat']);
+      expect(enumListToStringList('[hello,,world]')).toEqual(['hello', 'world']);
+      expect(enumListToStringList('[,, ,how are you? ]')).toEqual(['how are you?']);
+      expect(enumListToStringList('[ , HubHazard , , Hubitat]')).toEqual(['HubHazard', 'Hubitat']);
     });
 
     it('should return a valid list of values', () => {
-      expect(enumListToStringList('[auto, on, heat, cool]'))
-        .toEqual(['auto', 'on', 'heat', 'cool']);
-      expect(enumListToStringList('[a, a, a , a,a,a ]'))
-        .toEqual(['a', 'a', 'a', 'a', 'a', 'a']);
-      expect(enumListToStringList('[get up, get down, get off, get on, get by, get, get set]'))
-        .toEqual(['get up', 'get down', 'get off', 'get on', 'get by', 'get', 'get set']);
+      expect(enumListToStringList('[auto, on, heat, cool]')).toEqual(['auto', 'on', 'heat', 'cool']);
+      expect(enumListToStringList('[a, a, a , a,a,a ]')).toEqual(['a', 'a', 'a', 'a', 'a', 'a']);
+      expect(enumListToStringList('[get up, get down, get off, get on, get by, get, get set]')).toEqual([
+        'get up',
+        'get down',
+        'get off',
+        'get on',
+        'get by',
+        'get',
+        'get set',
+      ]);
     });
   });
 });

--- a/src/hubitat-capabilities/capabilities.helpers.ts
+++ b/src/hubitat-capabilities/capabilities.helpers.ts
@@ -59,7 +59,7 @@ export function getDevice(deviceOrId: HubitatDevice | number): HubitatDevice {
  */
 export function enumListToStringList(enumList: string): string[] {
   // Check if the enumList string is within []
-  if (enumList.length < 2 ||  enumList.charAt(0) !== '[' || enumList.charAt(enumList.length -1) !== ']')  {
+  if (enumList.length < 2 || enumList.charAt(0) !== '[' || enumList.charAt(enumList.length - 1) !== ']') {
     console.error(`Failed to convert the enum list ("${enumList}") into string list.`);
     return [];
   }
@@ -68,7 +68,8 @@ export function enumListToStringList(enumList: string): string[] {
   enumList = enumList.substring(1, enumList.length - 1);
 
   // Extract values
-  return enumList.split(',')
-    .map(value => value.trim())
-    .filter(value => value.length > 0);
+  return enumList
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
 }

--- a/src/hubitat-capabilities/capabilities.helpers.ts
+++ b/src/hubitat-capabilities/capabilities.helpers.ts
@@ -51,3 +51,24 @@ export function getDevice(deviceOrId: HubitatDevice | number): HubitatDevice {
   }
   return deviceOrId;
 }
+
+/**
+ * Convert the *enum list* received from Hubitat into the JS-friendly string list.
+ * @param enumList An *enum list* from Hubitat in format: `[valueA, valueB, value C]`.
+ * @returns Returns a list of values as strings: `["valueA", "valueB", "value C"]` .
+ */
+export function enumListToStringList(enumList: string): string[] {
+  // Check if the enumList string is within []
+  if (enumList.length < 2 ||  enumList.charAt(0) !== '[' || enumList.charAt(enumList.length -1) !== ']')  {
+    console.error(`Failed to convert the enum list ("${enumList}") into string list.`);
+    return [];
+  }
+
+  // Remove surrounding brackets
+  enumList = enumList.substring(1, enumList.length - 1);
+
+  // Extract values
+  return enumList.split(',')
+    .map(value => value.trim())
+    .filter(value => value.length > 0);
+}

--- a/src/hubitat-capabilities/temperature-measurement.capability.ts
+++ b/src/hubitat-capabilities/temperature-measurement.capability.ts
@@ -27,3 +27,29 @@ export function getTemperature(deviceId: number): number;
 export function getTemperature(deviceOrId: HubitatDevice | number): number {
   return getDevice(deviceOrId).getAttributeAsFloat('temperature');
 }
+
+/**
+ * Sets the temperature measurement of a **virtual** temperature measurement device.
+ *
+ * @param device A target device.
+ * @param temperature A temperature to set.
+ * @category TemperatureMeasurement capability
+ */
+export async function setTemperature(device: HubitatDevice, temperature: number): Promise<void>;
+
+/**
+ * Sets the temperature measurement of a **virtual** temperature measurement device.
+ *
+ * @param deviceId An ID of the target device.
+ * @param temperature A temperature to set.
+ * @category TemperatureMeasurement capability
+ */
+export async function setTemperature(deviceId: number, temperature: number): Promise<void>;
+
+export async function setTemperature(deviceOrId: HubitatDevice | number, temperature: number): Promise<void> {
+  const command = 'setTemperature';
+  const device = getDevice(deviceOrId);
+  if (!device.hasCommand(command))
+    throw new Error(`The device '${device.name}' doesn't support the '${command}' command.`);
+  await device.sendCommand(command, temperature);
+}

--- a/src/hubitat-capabilities/thermostat.capability.ts
+++ b/src/hubitat-capabilities/thermostat.capability.ts
@@ -1,0 +1,173 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice, getDevice } from "index";
+import { json } from "express";
+
+/* ==== Cooling setpoint ==== */
+
+/**
+ * Returns current thermostat cooling setpoint.
+ *
+ * @param device A target device.
+ * @returns Returns current thermostat cooling setpoint.
+ * @category Thermostat capability
+ */
+export function getCoolingSetpoint(device: HubitatDevice): number;
+
+/**
+ * Returns current thermostat cooling setpoint.
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns current thermostat cooling setpoint.
+ * @category Thermostat capability
+ */
+export function getCoolingSetpoint(deviceId: number): number;
+
+export function getCoolingSetpoint(deviceOrId: HubitatDevice | number): number {
+  return getDevice(deviceOrId).getAttributeAsFloat('coolingSetpoint');
+}
+
+/**
+ * Sets the thermostat cooling setpoint to a specified temperature.
+ *
+ * @param device A target device.
+ * @param temperature A temperature to set the cooling setpoint to.
+ * @category Thermostat capability
+ */
+export async function setCoolingSetpoint(device: HubitatDevice, temperature: number): Promise<void>;
+
+/**
+ * Sets the thermostat cooling setpoint to a specified temperature.
+ *
+ * @param deviceId An ID of the target device.
+ * @param temperature A temperature to set the cooling setpoint to.
+ * @category Thermostat capability
+ */
+export async function setCoolingSetpoint(deviceId: number, temperature: number): Promise<void>;
+
+export async function setCoolingSetpoint(deviceOrId: HubitatDevice | number, temperature: number): Promise<void> {
+  const device = getDevice(deviceOrId);
+  await device.sendCommand('setCoolingSetpoint', temperature);
+}
+
+/* ==== Heating setpoint ==== */
+
+/**
+ * Returns current thermostat heating setpoint.
+ *
+ * @param device A target device.
+ * @returns Returns current thermostat heating setpoint.
+ * @category Thermostat capability
+ */
+export function getHeatingSetpoint(device: HubitatDevice): number;
+
+/**
+ * Returns current thermostat heating setpoint.
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns current thermostat heating setpoint.
+ * @category Thermostat capability
+ */
+export function getHeatingSetpoint(deviceId: number): number;
+
+export function getHeatingSetpoint(deviceOrId: HubitatDevice | number): number {
+  return getDevice(deviceOrId).getAttributeAsFloat('heatingSetpoint');
+}
+
+/**
+ * Sets the thermostat heating setpoint to a specified temperature.
+ *
+ * @param device A target device.
+ * @param temperature A temperature to set the heating setpoint to.
+ * @category Thermostat capability
+ */
+export async function setHeatingSetpoint(device: HubitatDevice, temperature: number): Promise<void>;
+
+/**
+ * Sets the thermostat heating setpoint to a specified temperature.
+ *
+ * @param deviceId An ID of the target device.
+ * @param temperature A temperature to set the heating setpoint to.
+ * @category Thermostat capability
+ */
+export async function setHeatingSetpoint(deviceId: number, temperature: number): Promise<void>;
+
+export async function setHeatingSetpoint(deviceOrId: HubitatDevice | number, temperature: number): Promise<void> {
+  const device = getDevice(deviceOrId);
+  await device.sendCommand('setHeatingSetpoint', temperature);
+}
+
+/* ==== Schedule ==== */
+
+/**
+ * Returns current thermostat schedule.
+ *
+ * @param device A target device.
+ * @returns Returns current thermostat schedule.
+ * @category Thermostat capability
+ */
+export function getThermostatSchedule(device: HubitatDevice): Object;
+
+/**
+ * Returns current thermostat schedule.
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns current thermostat schedule.
+ * @category Thermostat capability
+ */
+export function getThermostatSchedule(deviceId: number): Object;
+
+export function getThermostatSchedule(deviceOrId: HubitatDevice | number): Object {
+  const scheduleString = getDevice(deviceOrId).getAttributeAsString('schedule') ?? '{}';
+  return JSON.parse(scheduleString);
+}
+
+/**
+ * Sets the thermostat schedule.
+ *
+ * @param device A target device.
+ * @param schedule A schedule data.
+ * @category Thermostat capability
+ */
+export async function setThermostatSchedule(device: HubitatDevice, schedule: Object): Promise<void>;
+
+/**
+ * Sets the thermostat schedule.
+ *
+ * @param deviceId An ID of the target device.
+ * @param schedule A schedule data.
+ * @category Thermostat capability
+ */
+export async function setThermostatSchedule(deviceId: number, schedule: Object): Promise<void>;
+
+export async function setThermostatSchedule(deviceOrId: HubitatDevice | number, schedule: Object): Promise<void> {
+  const device = getDevice(deviceOrId);
+  await device.sendCommand('setSchedule', JSON.stringify(schedule));
+}
+
+/* ==== Thermostat Setpoint ==== */
+
+/**
+ * Returns current thermostat setpoint.
+ *
+ * @param device A target device.
+ * @returns Returns current thermostat setpoint.
+ * @category Thermostat capability
+ */
+export function getThermostatSetpoint(device: HubitatDevice): number;
+
+/**
+ * Returns current thermostat setpoint.
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns current thermostat setpoint.
+ * @category Thermostat capability
+ */
+export function getThermostatSetpoint(deviceId: number): number;
+
+export function getThermostatSetpoint(deviceOrId: HubitatDevice | number): number {
+  return getDevice(deviceOrId).getAttributeAsFloat('thermostatSetpoint');
+}

--- a/src/hubitat-capabilities/thermostat.capability.ts
+++ b/src/hubitat-capabilities/thermostat.capability.ts
@@ -3,10 +3,19 @@
  * @module HubitatCapabilities
  */
 
-import { HubitatDevice, getDevice } from "index";
-import { json } from "express";
+import { HubitatDevice } from '../hubitat-device-events/hubitat-device';
+import { enumListToStringList, getDevice } from './capabilities.helpers';
 
-/* ==== Cooling setpoint ==== */
+export { getTemperature as getThermostatTemperature } from './temperature-measurement.capability';
+
+export type EThermostatFanMode = 'on' | 'circulate' | 'auto';
+export type EThermostatMode = 'auto' | 'off' | 'heat' | 'emergency heat' | 'cool';
+export type EThermostatOperatingState =
+  'heating' | 'pending cool' | 'pending heat' | 'vent economizer' | 'idle' | 'cooling' | 'fan only';
+
+/* ==========================================
+ *     Cooling setpoint
+ * ========================================== */
 
 /**
  * Returns current thermostat cooling setpoint.
@@ -53,7 +62,9 @@ export async function setCoolingSetpoint(deviceOrId: HubitatDevice | number, tem
   await device.sendCommand('setCoolingSetpoint', temperature);
 }
 
-/* ==== Heating setpoint ==== */
+/* ==========================================
+ *     Heating setpoint
+ * ========================================== */
 
 /**
  * Returns current thermostat heating setpoint.
@@ -100,7 +111,9 @@ export async function setHeatingSetpoint(deviceOrId: HubitatDevice | number, tem
   await device.sendCommand('setHeatingSetpoint', temperature);
 }
 
-/* ==== Schedule ==== */
+/* ==========================================
+ *     Schedule
+ * ========================================== */
 
 /**
  * Returns current thermostat schedule.
@@ -109,7 +122,7 @@ export async function setHeatingSetpoint(deviceOrId: HubitatDevice | number, tem
  * @returns Returns current thermostat schedule.
  * @category Thermostat capability
  */
-export function getThermostatSchedule(device: HubitatDevice): Object;
+export function getThermostatSchedule(device: HubitatDevice): Record<string, any>;
 
 /**
  * Returns current thermostat schedule.
@@ -118,9 +131,9 @@ export function getThermostatSchedule(device: HubitatDevice): Object;
  * @returns Returns current thermostat schedule.
  * @category Thermostat capability
  */
-export function getThermostatSchedule(deviceId: number): Object;
+export function getThermostatSchedule(deviceId: number): Record<string, any>;
 
-export function getThermostatSchedule(deviceOrId: HubitatDevice | number): Object {
+export function getThermostatSchedule(deviceOrId: HubitatDevice | number): Record<string, any> {
   const scheduleString = getDevice(deviceOrId).getAttributeAsString('schedule') ?? '{}';
   return JSON.parse(scheduleString);
 }
@@ -132,7 +145,7 @@ export function getThermostatSchedule(deviceOrId: HubitatDevice | number): Objec
  * @param schedule A schedule data.
  * @category Thermostat capability
  */
-export async function setThermostatSchedule(device: HubitatDevice, schedule: Object): Promise<void>;
+export async function setThermostatSchedule(device: HubitatDevice, schedule: Record<string, any>): Promise<void>;
 
 /**
  * Sets the thermostat schedule.
@@ -141,14 +154,281 @@ export async function setThermostatSchedule(device: HubitatDevice, schedule: Obj
  * @param schedule A schedule data.
  * @category Thermostat capability
  */
-export async function setThermostatSchedule(deviceId: number, schedule: Object): Promise<void>;
+export async function setThermostatSchedule(deviceId: number, schedule: Record<string, any>): Promise<void>;
 
-export async function setThermostatSchedule(deviceOrId: HubitatDevice | number, schedule: Object): Promise<void> {
+export async function setThermostatSchedule(deviceOrId: HubitatDevice | number, schedule: Record<string, any>): Promise<void> {
   const device = getDevice(deviceOrId);
   await device.sendCommand('setSchedule', JSON.stringify(schedule));
 }
 
-/* ==== Thermostat Setpoint ==== */
+/* ==========================================
+ *     Thermostat supported fan modes
+ * ========================================== */
+
+/**
+ * Returns a list of fan modes supported by specified thermostat.
+ *
+ * @param device A target device.
+ * @returns Returns a list of fan modes supported by specified thermostat.
+ * @category Thermostat capability
+ */
+export function getSupportedThermostatFanModes(device: HubitatDevice): EThermostatFanMode[];
+
+/**
+ * Returns a list of fan modes supported by specified thermostat.
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns a list of fan modes supported by specified thermostat.
+ * @category Thermostat capability
+ */
+export function getSupportedThermostatFanModes(deviceId: number): EThermostatFanMode[];
+
+export function getSupportedThermostatFanModes(deviceOrId: HubitatDevice | number): EThermostatFanMode[] {
+  const valueList = getDevice(deviceOrId).getAttributeAsString('supportedThermostatFanModes') ?? '[]';
+  return enumListToStringList(valueList) as EThermostatFanMode[];
+}
+
+/**
+ * Sets the supported fan modes of a **virtual** thermostat device.
+ *
+ * @param device A target device.
+ * @param modes A list of supported fan modes to set.
+ * @category Thermostat capability
+ */
+export async function setSupportedThermostatFanModes(device: HubitatDevice, modes: EThermostatFanMode[]): Promise<void>;
+
+/**
+ * Sets the supported fan modes of a **virtual** thermostat device.
+ *
+ * @param deviceId An ID of the target device.
+ * @param modes A list of supported fan modes to set.
+ * @category Thermostat capability
+ */
+export async function setSupportedThermostatFanModes(deviceId: number, modes: EThermostatFanMode[]): Promise<void>;
+
+export async function setSupportedThermostatFanModes(deviceOrId: HubitatDevice | number, modes: EThermostatFanMode[]): Promise<void> {
+  const command = 'setSupportedThermostatFanModes';
+  const device = getDevice(deviceOrId);
+  if (!device.hasCommand(command))
+    throw new Error(`The device '${device.name}' doesn't support the '${command}' command.`);
+  await device.sendCommand(command, JSON.stringify(modes));
+}
+
+/* ==========================================
+ *     Thermostat supported modes
+ * ========================================== */
+
+/**
+ * Returns a list of modes supported by specified thermostat.
+ *
+ * @param device A target device.
+ * @returns Returns a list of modes supported by specified thermostat.
+ * @category Thermostat capability
+ */
+export function getSupportedThermostatModes(device: HubitatDevice): EThermostatMode[];
+
+/**
+ * Returns a list of modes supported by specified thermostat.
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns a list of modes supported by specified thermostat.
+ * @category Thermostat capability
+ */
+export function getSupportedThermostatModes(deviceId: number): EThermostatMode[];
+
+export function getSupportedThermostatModes(deviceOrId: HubitatDevice | number): EThermostatMode[] {
+  const valueList = getDevice(deviceOrId).getAttributeAsString('supportedThermostatModes') ?? '[]';
+  return enumListToStringList(valueList) as EThermostatMode[];
+}
+
+/**
+ * Sets the supported modes of a **virtual** thermostat device.
+ *
+ * @param device A target device.
+ * @param modes A list of supported modes to set.
+ * @category Thermostat capability
+ */
+export async function setSupportedThermostatModes(device: HubitatDevice, modes: EThermostatMode[]): Promise<void>;
+
+/**
+ * Sets the supported modes of a **virtual** thermostat device.
+ *
+ * @param deviceId An ID of the target device.
+ * @param modes A list of supported modes to set.
+ * @category Thermostat capability
+ */
+export async function setSupportedThermostatModes(deviceId: number, modes: EThermostatMode[]): Promise<void>;
+
+export async function setSupportedThermostatModes(deviceOrId: HubitatDevice | number, modes: EThermostatMode[]): Promise<void> {
+  const command = 'setSupportedThermostatModes';
+  const device = getDevice(deviceOrId);
+  if (!device.hasCommand(command))
+    throw new Error(`The device '${device.name}' doesn't support the '${command}' command.`);
+  await device.sendCommand(command, JSON.stringify(modes));
+}
+
+/* ==========================================
+ *     Thermostat fan mode
+ * ========================================== */
+
+/**
+ * Returns current thermostat fan mode.
+ *
+ * @param device A target device.
+ * @param defaultValue A value returned in case of invalid value returned by Hubitat.
+ * @returns Returns current thermostat fan mode.
+ * @category Thermostat capability
+ */
+export function getThermostatFanMode(device: HubitatDevice, defaultValue: EThermostatFanMode): EThermostatFanMode;
+
+/**
+ * Returns current thermostat fan mode.
+ *
+ * @param deviceId An ID of the target device.
+ * @param defaultValue A value returned in case of invalid value returned by Hubitat.
+ * @returns Returns current thermostat fan mode.
+ * @category Thermostat capability
+ */
+export function getThermostatFanMode(deviceId: number, defaultValue: EThermostatFanMode): EThermostatFanMode;
+
+export function getThermostatFanMode(deviceOrId: HubitatDevice | number, defaultValue: EThermostatFanMode = 'auto'): EThermostatFanMode {
+  const fanMode = getDevice(deviceOrId).getAttributeAsString('thermostatFanMode') ?? defaultValue;
+  return fanMode as EThermostatFanMode;
+}
+
+/**
+ * Sets the thermostat fan mode.
+ *
+ * @param device A target device.
+ * @param mode A fan mode to set.
+ * @category Thermostat capability
+ */
+export async function setThermostatFanMode(device: HubitatDevice, mode: EThermostatFanMode): Promise<void>;
+
+/**
+ * Sets the thermostat fan mode.
+ *
+ * @param deviceId An ID of the target device.
+ * @param mode A fan mode to set.
+ * @category Thermostat capability
+ */
+export async function setThermostatFanMode(deviceId: number, mode: EThermostatFanMode): Promise<void>;
+
+export async function setThermostatFanMode(deviceOrId: HubitatDevice | number, mode: EThermostatFanMode): Promise<void> {
+  const device = getDevice(deviceOrId);
+  await device.sendCommand('setThermostatFanMode', mode);
+}
+
+/* ==========================================
+ *     Thermostat mode
+ * ========================================== */
+
+/**
+ * Returns current thermostat mode.
+ *
+ * @param device A target device.
+ * @param defaultValue A value returned in case of invalid value returned by Hubitat.
+ * @returns Returns current thermostat mode.
+ * @category Thermostat capability
+ */
+export function getThermostatMode(device: HubitatDevice, defaultValue: EThermostatMode): EThermostatMode;
+
+/**
+ * Returns current thermostat mode.
+ *
+ * @param deviceId An ID of the target device.
+ * @param defaultValue A value returned in case of invalid value returned by Hubitat.
+ * @returns Returns current thermostat mode.
+ * @category Thermostat capability
+ */
+export function getThermostatMode(deviceId: number, defaultValue: EThermostatMode): EThermostatMode;
+
+export function getThermostatMode(deviceOrId: HubitatDevice | number, defaultValue: EThermostatMode = 'auto'): EThermostatMode {
+  const fanMode = getDevice(deviceOrId).getAttributeAsString('thermostatMode') ?? defaultValue;
+  return fanMode as EThermostatMode;
+}
+
+/**
+ * Sets the thermostat mode.
+ *
+ * @param device A target device.
+ * @param mode A mode to set.
+ * @category Thermostat capability
+ */
+export async function setThermostatMode(device: HubitatDevice, mode: EThermostatMode): Promise<void>;
+
+/**
+ * Sets the thermostat mode.
+ *
+ * @param deviceId An ID of the target device.
+ * @param mode A mode to set.
+ * @category Thermostat capability
+ */
+export async function setThermostatMode(deviceId: number, mode: EThermostatMode): Promise<void>;
+
+export async function setThermostatMode(deviceOrId: HubitatDevice | number, mode: EThermostatMode): Promise<void> {
+  const device = getDevice(deviceOrId);
+  await device.sendCommand('setThermostatMode', mode);
+}
+
+/* ==========================================
+ *     Thermostat operating state
+ * ========================================== */
+
+/**
+ * Returns current operating state of the thermostat.
+ *
+ * @param device A target device.
+ * @param defaultValue A value returned in case of invalid value returned by Hubitat.
+ * @returns Returns current operating state of the thermostat.
+ * @category Thermostat capability
+ */
+export function getThermostatOperatingState(device: HubitatDevice, defaultValue: EThermostatOperatingState): EThermostatOperatingState;
+
+/**
+ * Returns current operating state of the thermostat.
+ *
+ * @param deviceId An ID of the target device.
+ * @param defaultValue A value returned in case of invalid value returned by Hubitat.
+ * @returns Returns current operating state of the thermostat.
+ * @category Thermostat capability
+ */
+export function getThermostatOperatingState(deviceId: number, defaultValue: EThermostatOperatingState): EThermostatOperatingState;
+
+export function getThermostatOperatingState(deviceOrId: HubitatDevice | number, defaultValue: EThermostatOperatingState = 'idle'): EThermostatOperatingState {
+  const operatingState = getDevice(deviceOrId).getAttributeAsString('thermostatOperatingState') ?? defaultValue;
+  return operatingState as EThermostatOperatingState;
+}
+
+/**
+ * Sets the operating mode of a **virtual** thermostat device.
+ *
+ * @param device A target device.
+ * @param mode An operating mode to set.
+ * @category Thermostat capability
+ */
+export async function setThermostatOperatingState(device: HubitatDevice, mode: EThermostatOperatingState): Promise<void>;
+
+/**
+ * Sets the operating mode of a **virtual** thermostat device.
+ *
+ * @param deviceId An ID of the target device.
+ * @param mode An operating mode to set.
+ * @category Thermostat capability
+ */
+export async function setThermostatOperatingState(deviceId: number, mode: EThermostatOperatingState): Promise<void>;
+
+export async function setThermostatOperatingState(deviceOrId: HubitatDevice | number, mode: EThermostatOperatingState): Promise<void> {
+  const command = 'setThermostatOperatingState';
+  const device = getDevice(deviceOrId);
+  if (!device.hasCommand(command))
+    throw new Error(`The device '${device.name}' doesn't support the '${command}' command.`);
+  await device.sendCommand(command, mode);
+}
+
+/* ==========================================
+ *     Thermostat Setpoint
+ * ========================================== */
 
 /**
  * Returns current thermostat setpoint.
@@ -171,3 +451,4 @@ export function getThermostatSetpoint(deviceId: number): number;
 export function getThermostatSetpoint(deviceOrId: HubitatDevice | number): number {
   return getDevice(deviceOrId).getAttributeAsFloat('thermostatSetpoint');
 }
+

--- a/src/hubitat-capabilities/thermostat.capability.ts
+++ b/src/hubitat-capabilities/thermostat.capability.ts
@@ -11,7 +11,13 @@ export { getTemperature as getThermostatTemperature } from './temperature-measur
 export type EThermostatFanMode = 'on' | 'circulate' | 'auto';
 export type EThermostatMode = 'auto' | 'off' | 'heat' | 'emergency heat' | 'cool';
 export type EThermostatOperatingState =
-  'heating' | 'pending cool' | 'pending heat' | 'vent economizer' | 'idle' | 'cooling' | 'fan only';
+  | 'heating'
+  | 'pending cool'
+  | 'pending heat'
+  | 'vent economizer'
+  | 'idle'
+  | 'cooling'
+  | 'fan only';
 
 /* ==========================================
  *     Cooling setpoint
@@ -156,7 +162,10 @@ export async function setThermostatSchedule(device: HubitatDevice, schedule: Rec
  */
 export async function setThermostatSchedule(deviceId: number, schedule: Record<string, any>): Promise<void>;
 
-export async function setThermostatSchedule(deviceOrId: HubitatDevice | number, schedule: Record<string, any>): Promise<void> {
+export async function setThermostatSchedule(
+  deviceOrId: HubitatDevice | number,
+  schedule: Record<string, any>,
+): Promise<void> {
   const device = getDevice(deviceOrId);
   await device.sendCommand('setSchedule', JSON.stringify(schedule));
 }
@@ -206,7 +215,10 @@ export async function setSupportedThermostatFanModes(device: HubitatDevice, mode
  */
 export async function setSupportedThermostatFanModes(deviceId: number, modes: EThermostatFanMode[]): Promise<void>;
 
-export async function setSupportedThermostatFanModes(deviceOrId: HubitatDevice | number, modes: EThermostatFanMode[]): Promise<void> {
+export async function setSupportedThermostatFanModes(
+  deviceOrId: HubitatDevice | number,
+  modes: EThermostatFanMode[],
+): Promise<void> {
   const command = 'setSupportedThermostatFanModes';
   const device = getDevice(deviceOrId);
   if (!device.hasCommand(command))
@@ -259,7 +271,10 @@ export async function setSupportedThermostatModes(device: HubitatDevice, modes: 
  */
 export async function setSupportedThermostatModes(deviceId: number, modes: EThermostatMode[]): Promise<void>;
 
-export async function setSupportedThermostatModes(deviceOrId: HubitatDevice | number, modes: EThermostatMode[]): Promise<void> {
+export async function setSupportedThermostatModes(
+  deviceOrId: HubitatDevice | number,
+  modes: EThermostatMode[],
+): Promise<void> {
   const command = 'setSupportedThermostatModes';
   const device = getDevice(deviceOrId);
   if (!device.hasCommand(command))
@@ -291,7 +306,10 @@ export function getThermostatFanMode(device: HubitatDevice, defaultValue: ETherm
  */
 export function getThermostatFanMode(deviceId: number, defaultValue: EThermostatFanMode): EThermostatFanMode;
 
-export function getThermostatFanMode(deviceOrId: HubitatDevice | number, defaultValue: EThermostatFanMode = 'auto'): EThermostatFanMode {
+export function getThermostatFanMode(
+  deviceOrId: HubitatDevice | number,
+  defaultValue: EThermostatFanMode = 'auto',
+): EThermostatFanMode {
   const fanMode = getDevice(deviceOrId).getAttributeAsString('thermostatFanMode') ?? defaultValue;
   return fanMode as EThermostatFanMode;
 }
@@ -314,7 +332,10 @@ export async function setThermostatFanMode(device: HubitatDevice, mode: EThermos
  */
 export async function setThermostatFanMode(deviceId: number, mode: EThermostatFanMode): Promise<void>;
 
-export async function setThermostatFanMode(deviceOrId: HubitatDevice | number, mode: EThermostatFanMode): Promise<void> {
+export async function setThermostatFanMode(
+  deviceOrId: HubitatDevice | number,
+  mode: EThermostatFanMode,
+): Promise<void> {
   const device = getDevice(deviceOrId);
   await device.sendCommand('setThermostatFanMode', mode);
 }
@@ -343,7 +364,10 @@ export function getThermostatMode(device: HubitatDevice, defaultValue: EThermost
  */
 export function getThermostatMode(deviceId: number, defaultValue: EThermostatMode): EThermostatMode;
 
-export function getThermostatMode(deviceOrId: HubitatDevice | number, defaultValue: EThermostatMode = 'auto'): EThermostatMode {
+export function getThermostatMode(
+  deviceOrId: HubitatDevice | number,
+  defaultValue: EThermostatMode = 'auto',
+): EThermostatMode {
   const fanMode = getDevice(deviceOrId).getAttributeAsString('thermostatMode') ?? defaultValue;
   return fanMode as EThermostatMode;
 }
@@ -383,7 +407,10 @@ export async function setThermostatMode(deviceOrId: HubitatDevice | number, mode
  * @returns Returns current operating state of the thermostat.
  * @category Thermostat capability
  */
-export function getThermostatOperatingState(device: HubitatDevice, defaultValue: EThermostatOperatingState): EThermostatOperatingState;
+export function getThermostatOperatingState(
+  device: HubitatDevice,
+  defaultValue: EThermostatOperatingState,
+): EThermostatOperatingState;
 
 /**
  * Returns current operating state of the thermostat.
@@ -393,9 +420,15 @@ export function getThermostatOperatingState(device: HubitatDevice, defaultValue:
  * @returns Returns current operating state of the thermostat.
  * @category Thermostat capability
  */
-export function getThermostatOperatingState(deviceId: number, defaultValue: EThermostatOperatingState): EThermostatOperatingState;
+export function getThermostatOperatingState(
+  deviceId: number,
+  defaultValue: EThermostatOperatingState,
+): EThermostatOperatingState;
 
-export function getThermostatOperatingState(deviceOrId: HubitatDevice | number, defaultValue: EThermostatOperatingState = 'idle'): EThermostatOperatingState {
+export function getThermostatOperatingState(
+  deviceOrId: HubitatDevice | number,
+  defaultValue: EThermostatOperatingState = 'idle',
+): EThermostatOperatingState {
   const operatingState = getDevice(deviceOrId).getAttributeAsString('thermostatOperatingState') ?? defaultValue;
   return operatingState as EThermostatOperatingState;
 }
@@ -407,7 +440,10 @@ export function getThermostatOperatingState(deviceOrId: HubitatDevice | number, 
  * @param mode An operating mode to set.
  * @category Thermostat capability
  */
-export async function setThermostatOperatingState(device: HubitatDevice, mode: EThermostatOperatingState): Promise<void>;
+export async function setThermostatOperatingState(
+  device: HubitatDevice,
+  mode: EThermostatOperatingState,
+): Promise<void>;
 
 /**
  * Sets the operating mode of a **virtual** thermostat device.
@@ -418,7 +454,10 @@ export async function setThermostatOperatingState(device: HubitatDevice, mode: E
  */
 export async function setThermostatOperatingState(deviceId: number, mode: EThermostatOperatingState): Promise<void>;
 
-export async function setThermostatOperatingState(deviceOrId: HubitatDevice | number, mode: EThermostatOperatingState): Promise<void> {
+export async function setThermostatOperatingState(
+  deviceOrId: HubitatDevice | number,
+  mode: EThermostatOperatingState,
+): Promise<void> {
   const command = 'setThermostatOperatingState';
   const device = getDevice(deviceOrId);
   if (!device.hasCommand(command))
@@ -451,4 +490,3 @@ export function getThermostatSetpoint(deviceId: number): number;
 export function getThermostatSetpoint(deviceOrId: HubitatDevice | number): number {
   return getDevice(deviceOrId).getAttributeAsFloat('thermostatSetpoint');
 }
-


### PR DESCRIPTION
- Added capability functions for thermostat devices:
  * `getCoolingSetpoint` and `setCoolingSetpoint`
  * `getHeatingSetpoint` and `setHeatingSetpoint`
  * `getThermostatSchedule` and `setThermostatSchedule`
  * `getSupportedThermostatFanModes`
  * `getSupportedThermostatModes`
  * `getThermostatFanMode` and `setThermostatFanMode`
  * `getThermostatMode` and `setThermostatMode`
  * `getThermostatOperatingState`
  * `getThermostatSetpoint` and `setThermostatSetpoint`
- Added capability functions for virtual thermostat devices:
  * `setSupportedThermostatFanModes`
  * `setSupportedThermostatModes`
  * `setThermostatOperatingState`
- Added capability function for virtual temperature sensor devices: `setTemperature`.
- Added capability-related helper function `enumListToStringList`.

Related to #11 