### PR TITLE
Implement value comparison change filters #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,24 +17,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new event value filters when building Hubitat device event trigger definitions:
+  - `isGreaterThan` and `wasGreaterThan` - accepts the event if new/previous value is greater than the one specified.
+  - `isLesserThan` and `wasLesserThan` - accepts the event if new/previous value is lesser than the one specified.
+  - `increase` and `decrease` - accepts the event if the value increased/decreased.
+  - `customFilter` - allows to pass a custom event-matching function to be used.
+
 ## [0.1.0-beta.6] - 2020-08-27
 
 ### Added
 
 - Added capability functions for thermostat devices:
-  * `getCoolingSetpoint` and `setCoolingSetpoint`
-  * `getHeatingSetpoint` and `setHeatingSetpoint`
-  * `getThermostatSchedule` and `setThermostatSchedule`
-  * `getSupportedThermostatFanModes`
-  * `getSupportedThermostatModes`
-  * `getThermostatFanMode` and `setThermostatFanMode`
-  * `getThermostatMode` and `setThermostatMode`
-  * `getThermostatOperatingState`
-  * `getThermostatSetpoint` and `setThermostatSetpoint`
+  - `getCoolingSetpoint` and `setCoolingSetpoint`
+  - `getHeatingSetpoint` and `setHeatingSetpoint`
+  - `getThermostatSchedule` and `setThermostatSchedule`
+  - `getSupportedThermostatFanModes`
+  - `getSupportedThermostatModes`
+  - `getThermostatFanMode` and `setThermostatFanMode`
+  - `getThermostatMode` and `setThermostatMode`
+  - `getThermostatOperatingState`
+  - `getThermostatSetpoint` and `setThermostatSetpoint`
 - Added capability functions for virtual thermostat devices:
-  * `setSupportedThermostatFanModes`
-  * `setSupportedThermostatModes`
-  * `setThermostatOperatingState`
+  - `setSupportedThermostatFanModes`
+  - `setSupportedThermostatModes`
+  - `setThermostatOperatingState`
 - Added capability function for virtual temperature sensor devices: `setTemperature`.
 - Added capability-related helper function `enumListToStringList`.
 - Added `isHubitatDeviceEvent` and `isTimerEvent` functions for easier checking events and triggers types.
@@ -47,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The `Automation.handleEvent` function isn't marked as *internal* anymore.
+- The `Automation.handleEvent` function isn't marked as _internal_ anymore.
 - Documentation links now direct to the project wiki
 - Roadmap section now leads to a list of issues with a `task` label
 
@@ -84,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `common` functions set to mostly simplify interactions with collections and random number generation for
   testing purposes.
 
-[Unreleased]: https://github.com/hubhazard/core/compare/v0.1.0-beta.6...HEAD
+[unreleased]: https://github.com/hubhazard/core/compare/v0.1.0-beta.6...HEAD
 [0.1.0-beta.6]: https://github.com/hubhazard/core/compare/v0.1.0-beta.5...v0.1.0-beta.6
 [0.1.0-beta.5]: https://github.com/hubhazard/core/compare/v0.1.0-beta.4...v0.1.0-beta.5
 [0.1.0-beta.4]: https://github.com/hubhazard/core/compare/v0.1.0-beta.3...v0.1.0-beta.4

--- a/src/hubitat-device-events/definition-building/await-change-filter.definition.spec.ts
+++ b/src/hubitat-device-events/definition-building/await-change-filter.definition.spec.ts
@@ -10,13 +10,16 @@ import { randomIntRange } from '../../common/number-helpers';
 import { HubitatDeviceEvent } from '../hubitat-device-event';
 import { HubitatDevice } from '../hubitat-device';
 
-function createEvent(newValue: string | number | null, previousValue: string | number | null | undefined): HubitatDeviceEvent {
+function createEvent(
+  newValue: string | number | null,
+  previousValue: string | number | null | undefined,
+): HubitatDeviceEvent {
   return new HubitatDeviceEvent(
     'some-attribute',
     {} as HubitatDevice,
     randomIntRange(1, 300),
     newValue == null ? newValue : String(newValue),
-    previousValue == null ? previousValue : String(previousValue)
+    previousValue == null ? previousValue : String(previousValue),
   );
 }
 
@@ -73,7 +76,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (newValue: string | null) => {
         const event = createEvent(newValue, undefined);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).changes()
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .changes()
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBeTruthy();
       };
@@ -130,7 +135,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (newValue: string | null, filterValue: string | number | null, expected: boolean) => {
         const event = createEvent(newValue, undefined);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).is(filterValue)
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .is(filterValue)
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -201,7 +208,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (newValue: string | null, filterValue: string | number | null, expected: boolean) => {
         const event = createEvent(newValue, undefined);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).isNot(filterValue)
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .isNot(filterValue)
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -268,11 +277,16 @@ describe('AwaitChangeFilterDefinition', () => {
     });
 
     it('should accept only events with equal previousValue', () => {
-      const test = (previousValue: string | null | undefined,
-                    filterValue: string | number | null | undefined, expected: boolean) => {
+      const test = (
+        previousValue: string | null | undefined,
+        filterValue: string | number | null | undefined,
+        expected: boolean,
+      ) => {
         const event = createEvent(null, previousValue);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).was(filterValue)
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .was(filterValue)
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -347,10 +361,16 @@ describe('AwaitChangeFilterDefinition', () => {
     });
 
     it('should accept only events with not equal previousValue', () => {
-      const test = (previousValue: string | null | undefined, filterValue: string | number | null | undefined, expected: boolean) => {
+      const test = (
+        previousValue: string | null | undefined,
+        filterValue: string | number | null | undefined,
+        expected: boolean,
+      ) => {
         const event = createEvent(null, previousValue);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).wasNot(filterValue)
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .wasNot(filterValue)
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -427,7 +447,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (newValue: string | null, filterValue: number, expected: boolean) => {
         const event = createEvent(newValue, undefined);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).isGreaterThan(filterValue)
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .isGreaterThan(filterValue)
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -494,7 +516,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (previousValue: string | null | undefined, filterValue: number, expected: boolean) => {
         const event = createEvent(null, previousValue);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).wasGreaterThan(filterValue)
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .wasGreaterThan(filterValue)
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -566,7 +590,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (newValue: string | null, filterValue: number, expected: boolean) => {
         const event = createEvent(newValue, undefined);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).isLesserThan(filterValue)
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .isLesserThan(filterValue)
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -633,7 +659,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (previousValue: string | null | undefined, filterValue: number, expected: boolean) => {
         const event = createEvent(null, previousValue);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).wasLesserThan(filterValue)
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .wasLesserThan(filterValue)
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -705,7 +733,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (newValue: string | null, previousValue: string | null | undefined, expected: boolean) => {
         const event = createEvent(newValue, previousValue);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).increased()
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .increased()
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -783,7 +813,9 @@ describe('AwaitChangeFilterDefinition', () => {
       const test = (newValue: string | null, previousValue: string | null | undefined, expected: boolean) => {
         const event = createEvent(newValue, previousValue);
         const withAttributes = getWithAttributes();
-        const trigger = withAttributes.andWhere(event.attributeName).decreased()
+        const trigger = withAttributes
+          .andWhere(event.attributeName)
+          .decreased()
           .build() as HubitatDeviceTriggerDefinition;
         expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
       };
@@ -858,5 +890,4 @@ describe('AwaitChangeFilterDefinition', () => {
       }).toThrow();
     });
   });
-})
-;
+});

--- a/src/hubitat-device-events/definition-building/await-change-filter.definition.spec.ts
+++ b/src/hubitat-device-events/definition-building/await-change-filter.definition.spec.ts
@@ -35,16 +35,6 @@ describe('AwaitChangeFilterDefinition', () => {
       });
     });
 
-    it('should create filter with "changes" name', () => {
-      doTimes(15, () => {
-        const withAttributes = getWithAttributes();
-        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
-        const awaitingChangeFilter = withAttributes.andWhere(name.findName());
-        expect(awaitingChangeFilter.changes()).toBeInstanceOf(WithAttributesDefinition);
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.name).toEqual('changes');
-      });
-    });
-
     it('should throw error when there are no filter attributes', () => {
       const withAttributes = getWithAttributes();
       const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
@@ -80,18 +70,6 @@ describe('AwaitChangeFilterDefinition', () => {
         expect(awaitingChange.is(name.findName())).toBeInstanceOf(WithAttributesDefinition);
         expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
         expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
-      });
-    });
-
-    it('should create filter with "is" name and provided value', () => {
-      doTimes(15, () => {
-        const withAttributes = getWithAttributes();
-        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
-        const value = name.findName();
-        const awaitingChangeFilter = withAttributes.andWhere(name.findName());
-        expect(awaitingChangeFilter.is(value)).toBeInstanceOf(WithAttributesDefinition);
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.name).toEqual('is');
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.value).toEqual(value);
       });
     });
 
@@ -133,18 +111,6 @@ describe('AwaitChangeFilterDefinition', () => {
       });
     });
 
-    it('should create filter with "is-not" name and provided value', () => {
-      doTimes(15, () => {
-        const withAttributes = getWithAttributes();
-        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
-        const value = name.findName();
-        const awaitingChangeFilter = withAttributes.andWhere(name.findName());
-        expect(awaitingChangeFilter.isNot(value)).toBeInstanceOf(WithAttributesDefinition);
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.name).toEqual('is-not');
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.value).toEqual(value);
-      });
-    });
-
     it('should throw when there are no filter attributes', () => {
       const withAttributes = getWithAttributes();
       const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
@@ -183,18 +149,6 @@ describe('AwaitChangeFilterDefinition', () => {
       });
     });
 
-    it('should create filter with "was" name and provided value', () => {
-      doTimes(15, () => {
-        const withAttributes = getWithAttributes();
-        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
-        const value = name.findName();
-        const awaitingChangeFilter = withAttributes.andWhere(name.findName());
-        expect(awaitingChangeFilter.was(value)).toBeInstanceOf(WithAttributesDefinition);
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.name).toEqual('was');
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.value).toEqual(value);
-      });
-    });
-
     it('should throw when there are no filter attributes', () => {
       const withAttributes = getWithAttributes();
       const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
@@ -230,18 +184,6 @@ describe('AwaitChangeFilterDefinition', () => {
         expect(awaitingChange.wasNot(name.findName())).toBeInstanceOf(WithAttributesDefinition);
         expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
         expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
-      });
-    });
-
-    it('should create filter with "was-not" name and provided value', () => {
-      doTimes(15, () => {
-        const withAttributes = getWithAttributes();
-        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
-        const value = name.findName();
-        const awaitingChangeFilter = withAttributes.andWhere(name.findName());
-        expect(awaitingChangeFilter.wasNot(value)).toBeInstanceOf(WithAttributesDefinition);
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.name).toEqual('was-not');
-        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.value).toEqual(value);
       });
     });
 

--- a/src/hubitat-device-events/definition-building/await-change-filter.definition.spec.ts
+++ b/src/hubitat-device-events/definition-building/await-change-filter.definition.spec.ts
@@ -6,6 +6,19 @@ import { AwaitChangeFilterDefinition } from './await-change-filter.definition';
 import { randomDeviceTriggerDef } from './hubitat-device-trigger.spec';
 import { WithAttributesDefinition } from './with-attributes.definition';
 import { getWithAttributes } from './with-attributes.definition.spec';
+import { randomIntRange } from '../../common/number-helpers';
+import { HubitatDeviceEvent } from '../hubitat-device-event';
+import { HubitatDevice } from '../hubitat-device';
+
+function createEvent(newValue: string | number | null, previousValue: string | number | null | undefined): HubitatDeviceEvent {
+  return new HubitatDeviceEvent(
+    'some-attribute',
+    {} as HubitatDevice,
+    randomIntRange(1, 300),
+    newValue == null ? newValue : String(newValue),
+    previousValue == null ? previousValue : String(previousValue)
+  );
+}
 
 describe('AwaitChangeFilterDefinition', () => {
   describe('constructor', () => {
@@ -66,7 +79,6 @@ describe('AwaitChangeFilterDefinition', () => {
         const awaitingChange = new AwaitChangeFilterDefinition(trigger);
         const filtersNumber = trigger.lastAttribute?.lastGroup?.filters.length ?? -30;
         const lastFilter = trigger.lastAttribute?.lastGroup?.lastFilter;
-        // Use 'is'
         expect(awaitingChange.is(name.findName())).toBeInstanceOf(WithAttributesDefinition);
         expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
         expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
@@ -93,6 +105,39 @@ describe('AwaitChangeFilterDefinition', () => {
       expect(() => {
         awaitingChangeFilter.is(name.findName());
       }).toThrow();
+    });
+
+    it('should accept only events with equal newValue', () => {
+      const test = (newValue: string | null, filterValue: string | number | null, expected: boolean) => {
+        const event = createEvent(newValue, undefined);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).is(filterValue)
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Null values
+      test(null, null, true);
+      test(null, 'null', false);
+      test(null, 0, false);
+      test('null', null, false);
+
+      // String values
+      test('on', 'on', true);
+      test('on', 'off', false);
+
+      // Number values
+      test('6', 6, true);
+      test('0', 0, true);
+      test('-1356', -1356, true);
+      test('0.22', 0.22, true);
+      test('0.2199999999999', 0.22, false);
+      test('0.333337', 0.333337, true);
+      test('0.3333370001', 0.333337, false);
+      test('20066648497.12135', 20066648497.12135, true);
+      test('20066648497.12135', 20066648497.12136, false);
+      test('on', 3, false);
+      test('56', '56', true);
     });
   });
 
@@ -132,6 +177,39 @@ describe('AwaitChangeFilterDefinition', () => {
         awaitingChangeFilter.isNot(name.findName());
       }).toThrow();
     });
+
+    it('should accept only events with not equal newValue', () => {
+      const test = (newValue: string | null, filterValue: string | number | null, expected: boolean) => {
+        const event = createEvent(newValue, undefined);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).isNot(filterValue)
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Null values
+      test(null, null, false);
+      test(null, 'null', true);
+      test(null, 0, true);
+      test('null', null, true);
+
+      // String values
+      test('on', 'on', false);
+      test('on', 'off', true);
+
+      // Number values
+      test('6', 6, false);
+      test('0', 0, false);
+      test('-1356', -1356, false);
+      test('0.22', 0.22, false);
+      test('0.2199999999999', 0.22, true);
+      test('0.333337', 0.333337, false);
+      test('0.3333370001', 0.333337, true);
+      test('20066648497.12135', 20066648497.12135, false);
+      test('20066648497.12135', 20066648497.12136, true);
+      test('on', 3, true);
+      test('56', '56', false);
+    });
   });
 
   describe('was', () => {
@@ -142,7 +220,6 @@ describe('AwaitChangeFilterDefinition', () => {
         const awaitingChange = new AwaitChangeFilterDefinition(trigger);
         const filtersNumber = trigger.lastAttribute?.lastGroup?.filters.length ?? -30;
         const lastFilter = trigger.lastAttribute?.lastGroup?.lastFilter;
-        // Use 'was'
         expect(awaitingChange.was(name.findName())).toBeInstanceOf(WithAttributesDefinition);
         expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
         expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
@@ -169,6 +246,47 @@ describe('AwaitChangeFilterDefinition', () => {
       expect(() => {
         awaitingChangeFilter.was(name.findName());
       }).toThrow();
+    });
+
+    it('should accept only events with equal previousValue', () => {
+      const test = (previousValue: string | null | undefined,
+                    filterValue: string | number | null | undefined, expected: boolean) => {
+        const event = createEvent(null, previousValue);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).was(filterValue)
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Undefined values
+      test(undefined, undefined, true);
+      test(undefined, null, false);
+      test(undefined, 'null', false);
+      test(undefined, 0, false);
+      test(undefined, 'undefined', false);
+
+      // Null values
+      test(null, null, true);
+      test(null, 'null', false);
+      test(null, 0, false);
+      test('null', null, false);
+
+      // String values
+      test('on', 'on', true);
+      test('on', 'off', false);
+
+      // Number values
+      test('6', 6, true);
+      test('0', 0, true);
+      test('-1356', -1356, true);
+      test('0.22', 0.22, true);
+      test('0.2199999999999', 0.22, false);
+      test('0.333337', 0.333337, true);
+      test('0.3333370001', 0.333337, false);
+      test('20066648497.12135', 20066648497.12135, true);
+      test('20066648497.12135', 20066648497.12136, false);
+      test('on', 3, false);
+      test('56', '56', true);
     });
   });
 
@@ -208,5 +326,481 @@ describe('AwaitChangeFilterDefinition', () => {
         awaitingChangeFilter.wasNot(name.findName());
       }).toThrow();
     });
+
+    it('should accept only events with not equal previousValue', () => {
+      const test = (previousValue: string | null | undefined, filterValue: string | number | null | undefined, expected: boolean) => {
+        const event = createEvent(null, previousValue);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).wasNot(filterValue)
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Undefined values
+      test(undefined, undefined, false);
+      test(undefined, null, true);
+      test(undefined, 'null', true);
+      test(undefined, 0, true);
+      test(undefined, 'undefined', true);
+
+      // Null values
+      test(null, null, false);
+      test(null, 'null', true);
+      test(null, 0, true);
+      test('null', null, true);
+
+      // String values
+      test('on', 'on', false);
+      test('on', 'off', true);
+
+      // Number values
+      test('6', 6, false);
+      test('0', 0, false);
+      test('-1356', -1356, false);
+      test('0.22', 0.22, false);
+      test('0.2199999999999', 0.22, true);
+      test('0.333337', 0.333337, false);
+      test('0.3333370001', 0.333337, true);
+      test('20066648497.12135', 20066648497.12135, false);
+      test('20066648497.12135', 20066648497.12136, true);
+      test('on', 3, true);
+      test('56', '56', false);
+    });
   });
-});
+
+  describe('isGreaterThan', () => {
+    it('should add a new filter to the last group of a last attribute', () => {
+      doTimes(15, () => {
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+        const awaitingChange = new AwaitChangeFilterDefinition(trigger);
+        const filtersNumber = trigger.lastAttribute?.lastGroup?.filters.length ?? -30;
+        const lastFilter = trigger.lastAttribute?.lastGroup?.lastFilter;
+        expect(awaitingChange.isGreaterThan(randomIntRange(0, 100))).toBeInstanceOf(WithAttributesDefinition);
+        expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
+      });
+    });
+
+    it('should throw when there are no filter attributes', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      trigger.attributes = [];
+      expect(() => {
+        awaitingChangeFilter.isGreaterThan(randomIntRange(0, 100));
+      }).toThrow();
+    });
+
+    it('should throw when there are no changes groups', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      const { lastAttribute } = trigger;
+      if (lastAttribute == null) throw new Error(`There are no attributes!`);
+      lastAttribute.changeGroups = [];
+      expect(() => {
+        awaitingChangeFilter.isGreaterThan(randomIntRange(0, 100));
+      }).toThrow();
+    });
+
+    it('should accept only events with newValue greater than specified', () => {
+      const test = (newValue: string | null, filterValue: number, expected: boolean) => {
+        const event = createEvent(newValue, undefined);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).isGreaterThan(filterValue)
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Null values
+      test(null, 123, false);
+      test(null, 321.35, false);
+      test(null, -154, false);
+      test(null, -553.44948, false);
+
+      // String values
+      test('active', 153, false);
+      test('inactive', -556.8841, false);
+
+      // Number values
+      test('6', 6, false);
+      test('6', 5, true);
+      test('0', 1010.1, false);
+      test('1010.1001', 1010.1, true);
+      test('-1356', -1356, false);
+      test('-1350', -1356, true);
+      test('0.21', 0.22, false);
+      test('0.23', 0.22, true);
+    });
+  });
+
+  describe('wasGreaterThan', () => {
+    it('should add a new filter to the last group of a last attribute', () => {
+      doTimes(15, () => {
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+        const awaitingChange = new AwaitChangeFilterDefinition(trigger);
+        const filtersNumber = trigger.lastAttribute?.lastGroup?.filters.length ?? -30;
+        const lastFilter = trigger.lastAttribute?.lastGroup?.lastFilter;
+        expect(awaitingChange.wasGreaterThan(randomIntRange(0, 100))).toBeInstanceOf(WithAttributesDefinition);
+        expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
+      });
+    });
+
+    it('should throw when there are no filter attributes', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      trigger.attributes = [];
+      expect(() => {
+        awaitingChangeFilter.wasGreaterThan(randomIntRange(0, 100));
+      }).toThrow();
+    });
+
+    it('should throw when there are no changes groups', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      const { lastAttribute } = trigger;
+      if (lastAttribute == null) throw new Error(`There are no attributes!`);
+      lastAttribute.changeGroups = [];
+      expect(() => {
+        awaitingChangeFilter.wasGreaterThan(randomIntRange(0, 100));
+      }).toThrow();
+    });
+
+    it('should accept only events with previousValue greater than specified', () => {
+      const test = (previousValue: string | null | undefined, filterValue: number, expected: boolean) => {
+        const event = createEvent(null, previousValue);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).wasGreaterThan(filterValue)
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Undefined values
+      test(undefined, 0, false);
+      test(undefined, -1015, false);
+      test(undefined, 3151, false);
+
+      // Null values
+      test(null, 123, false);
+      test(null, 321.35, false);
+      test(null, -154, false);
+      test(null, -553.44948, false);
+
+      // String values
+      test('active', 153, false);
+      test('inactive', -556.8841, false);
+
+      // Number values
+      test('6', 6, false);
+      test('6', 5, true);
+      test('0', 1010.1, false);
+      test('1010.1001', 1010.1, true);
+      test('-1356', -1356, false);
+      test('-1350', -1356, true);
+      test('0.21', 0.22, false);
+      test('0.23', 0.22, true);
+    });
+  });
+
+  describe('isLesserThan', () => {
+    it('should add a new filter to the last group of a last attribute', () => {
+      doTimes(15, () => {
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+        const awaitingChange = new AwaitChangeFilterDefinition(trigger);
+        const filtersNumber = trigger.lastAttribute?.lastGroup?.filters.length ?? -30;
+        const lastFilter = trigger.lastAttribute?.lastGroup?.lastFilter;
+        expect(awaitingChange.isLesserThan(randomIntRange(0, 100))).toBeInstanceOf(WithAttributesDefinition);
+        expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
+      });
+    });
+
+    it('should throw when there are no filter attributes', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      trigger.attributes = [];
+      expect(() => {
+        awaitingChangeFilter.isLesserThan(randomIntRange(0, 100));
+      }).toThrow();
+    });
+
+    it('should throw when there are no changes groups', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      const { lastAttribute } = trigger;
+      if (lastAttribute == null) throw new Error(`There are no attributes!`);
+      lastAttribute.changeGroups = [];
+      expect(() => {
+        awaitingChangeFilter.isLesserThan(randomIntRange(0, 100));
+      }).toThrow();
+    });
+
+    it('should accept only events with newValue lesser than specified', () => {
+      const test = (newValue: string | null, filterValue: number, expected: boolean) => {
+        const event = createEvent(newValue, undefined);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).isLesserThan(filterValue)
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Null values
+      test(null, 123, false);
+      test(null, 321.35, false);
+      test(null, -154, false);
+      test(null, -553.44948, false);
+
+      // String values
+      test('active', 153, false);
+      test('inactive', -556.8841, false);
+
+      // Number values
+      test('6', 6, false);
+      test('4', 5, true);
+      test('0', 1010.1, true);
+      test('1010.0999', 1010.1, true);
+      test('-1350', -1356, false);
+      test('-1358', -1356, true);
+      test('0.21', 0.22, true);
+      test('0.23', 0.22, false);
+    });
+  });
+
+  describe('wasLesserThan', () => {
+    it('should add a new filter to the last group of a last attribute', () => {
+      doTimes(15, () => {
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+        const awaitingChange = new AwaitChangeFilterDefinition(trigger);
+        const filtersNumber = trigger.lastAttribute?.lastGroup?.filters.length ?? -30;
+        const lastFilter = trigger.lastAttribute?.lastGroup?.lastFilter;
+        expect(awaitingChange.wasLesserThan(randomIntRange(0, 100))).toBeInstanceOf(WithAttributesDefinition);
+        expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
+      });
+    });
+
+    it('should throw when there are no filter attributes', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      trigger.attributes = [];
+      expect(() => {
+        awaitingChangeFilter.wasLesserThan(randomIntRange(0, 100));
+      }).toThrow();
+    });
+
+    it('should throw when there are no changes groups', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      const { lastAttribute } = trigger;
+      if (lastAttribute == null) throw new Error(`There are no attributes!`);
+      lastAttribute.changeGroups = [];
+      expect(() => {
+        awaitingChangeFilter.wasLesserThan(randomIntRange(0, 100));
+      }).toThrow();
+    });
+
+    it('should accept only events with previousValue lesser than specified', () => {
+      const test = (previousValue: string | null | undefined, filterValue: number, expected: boolean) => {
+        const event = createEvent(null, previousValue);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).wasLesserThan(filterValue)
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Undefined values
+      test(undefined, 0, false);
+      test(undefined, -1015, false);
+      test(undefined, 3151, false);
+
+      // Null values
+      test(null, 123, false);
+      test(null, 321.35, false);
+      test(null, -154, false);
+      test(null, -553.44948, false);
+
+      // String values
+      test('active', 153, false);
+      test('inactive', -556.8841, false);
+
+      // Number values
+      test('6', 6, false);
+      test('4', 5, true);
+      test('0', 1010.1, true);
+      test('1010.0999', 1010.1, true);
+      test('-1350', -1356, false);
+      test('-1358', -1356, true);
+      test('0.21', 0.22, true);
+      test('0.23', 0.22, false);
+    });
+  });
+
+  describe('increased', () => {
+    it('should add a new filter to the last group of a last attribute', () => {
+      doTimes(15, () => {
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+        const awaitingChange = new AwaitChangeFilterDefinition(trigger);
+        const filtersNumber = trigger.lastAttribute?.lastGroup?.filters.length ?? -30;
+        const lastFilter = trigger.lastAttribute?.lastGroup?.lastFilter;
+        expect(awaitingChange.increased()).toBeInstanceOf(WithAttributesDefinition);
+        expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
+      });
+    });
+
+    it('should throw when there are no filter attributes', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      trigger.attributes = [];
+      expect(() => {
+        awaitingChangeFilter.increased();
+      }).toThrow();
+    });
+
+    it('should throw when there are no changes groups', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      const { lastAttribute } = trigger;
+      if (lastAttribute == null) throw new Error(`There are no attributes!`);
+      lastAttribute.changeGroups = [];
+      expect(() => {
+        awaitingChangeFilter.increased();
+      }).toThrow();
+    });
+
+    it('should accept only events where numerical value has increased', () => {
+      const test = (newValue: string | null, previousValue: string | null | undefined, expected: boolean) => {
+        const event = createEvent(newValue, previousValue);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).increased()
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Undefined values
+      test(null, undefined, false);
+      test('on', undefined, false);
+      test('-1', undefined, false);
+      test('1.5', undefined, false);
+
+      // Null values
+      test(null, null, false);
+      test('on', null, false);
+      test('-1', null, false);
+      test('1.5', null, false);
+
+      // String values
+      test(null, 'on', false);
+      test('on', 'off', false);
+      test('2', 'one', false);
+      test('40', 'five', false);
+      test('active', 'active', false);
+      test('active', 'inactive', false);
+
+      // Number values
+      test(null, '6', false);
+      test('on', '0', false);
+      test('50', '4', true);
+      test('0.00001', '0', true);
+      test('15999', '1010.0999', true);
+      test('-1351', '-1350', false);
+      test('-1357.999', '-1358', true);
+      test('1', '0.21', true);
+      test('-6', '0.23', false);
+    });
+  });
+
+  describe('decreased', () => {
+    it('should add a new filter to the last group of a last attribute', () => {
+      doTimes(15, () => {
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+        const awaitingChange = new AwaitChangeFilterDefinition(trigger);
+        const filtersNumber = trigger.lastAttribute?.lastGroup?.filters.length ?? -30;
+        const lastFilter = trigger.lastAttribute?.lastGroup?.lastFilter;
+        expect(awaitingChange.decreased()).toBeInstanceOf(WithAttributesDefinition);
+        expect(trigger.lastAttribute?.lastGroup?.filters.length).toEqual(filtersNumber + 1);
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter).not.toBe(lastFilter);
+      });
+    });
+
+    it('should throw when there are no filter attributes', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      trigger.attributes = [];
+      expect(() => {
+        awaitingChangeFilter.decreased();
+      }).toThrow();
+    });
+
+    it('should throw when there are no changes groups', () => {
+      const withAttributes = getWithAttributes();
+      const trigger = withAttributes.build() as HubitatDeviceTriggerDefinition;
+      const awaitingChangeFilter = withAttributes.andWhere(name.findName());
+      const { lastAttribute } = trigger;
+      if (lastAttribute == null) throw new Error(`There are no attributes!`);
+      lastAttribute.changeGroups = [];
+      expect(() => {
+        awaitingChangeFilter.decreased();
+      }).toThrow();
+    });
+
+    it('should accept only events where numerical value has decreased', () => {
+      const test = (newValue: string | null, previousValue: string | null | undefined, expected: boolean) => {
+        const event = createEvent(newValue, previousValue);
+        const withAttributes = getWithAttributes();
+        const trigger = withAttributes.andWhere(event.attributeName).decreased()
+          .build() as HubitatDeviceTriggerDefinition;
+        expect(trigger.lastAttribute?.lastGroup?.lastFilter?.match(event)).toBe(expected);
+      };
+
+      // Undefined values
+      test(null, undefined, false);
+      test('on', undefined, false);
+      test('-1', undefined, false);
+      test('1.5', undefined, false);
+
+      // Null values
+      test(null, null, false);
+      test('on', null, false);
+      test('-1', null, false);
+      test('1.5', null, false);
+
+      // String values
+      test(null, 'on', false);
+      test('on', 'off', false);
+      test('2', 'one', false);
+      test('40', 'five', false);
+      test('active', 'active', false);
+      test('active', 'inactive', false);
+
+      // Number values
+      test(null, '6', false);
+      test('on', '0', false);
+      test('50', '4', false);
+      test('0.00001', '0', false);
+      test('0', '0.00001', true);
+      test('15999', '1010.0999', false);
+      test('-1351', '-1350', true);
+      test('-1357.999', '-1358', false);
+      test('1', '0.21', false);
+      test('-6', '0.23', true);
+    });
+  });
+})
+;

--- a/src/hubitat-device-events/definition-building/await-change-filter.definition.ts
+++ b/src/hubitat-device-events/definition-building/await-change-filter.definition.ts
@@ -54,7 +54,7 @@ export class AwaitChangeFilterDefinition {
    */
   is(value: string | number | null): WithAttributesDefinition {
     return this.registerChangeFilter((event) => {
-      if (typeof (value) === 'number') return event.newValue === `${value}`;
+      if (typeof value === 'number') return event.newValue === `${value}`;
       return event.newValue === value;
     });
   }
@@ -77,7 +77,7 @@ export class AwaitChangeFilterDefinition {
    */
   was(value: string | number | null | undefined): WithAttributesDefinition {
     return this.registerChangeFilter((event) => {
-      if (typeof (value) === 'number') return event.previousValue === `${value}`;
+      if (typeof value === 'number') return event.previousValue === `${value}`;
       return event.previousValue === value;
     });
   }
@@ -99,7 +99,7 @@ export class AwaitChangeFilterDefinition {
    */
   isNot(value: string | number | null): WithAttributesDefinition {
     return this.registerChangeFilter((event) => {
-      if (typeof (value) === 'number') return event.newValue !== `${value}`;
+      if (typeof value === 'number') return event.newValue !== `${value}`;
       return event.newValue !== value;
     });
   }
@@ -122,7 +122,7 @@ export class AwaitChangeFilterDefinition {
    */
   wasNot(value: string | number | null | undefined): WithAttributesDefinition {
     return this.registerChangeFilter((event) => {
-      if (typeof (value) === 'number') return event.previousValue !== `${value}`;
+      if (typeof value === 'number') return event.previousValue !== `${value}`;
       return event.previousValue !== value;
     });
   }

--- a/src/hubitat-device-events/definition-building/await-change-filter.definition.ts
+++ b/src/hubitat-device-events/definition-building/await-change-filter.definition.ts
@@ -52,8 +52,11 @@ export class AwaitChangeFilterDefinition {
    *
    * @param value A value of the attribute that is required to match the trigger.
    */
-  is(value: string | number): WithAttributesDefinition {
-    return this.registerChangeFilter((event) => event.newValue === `${value}`);
+  is(value: string | number | null): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (typeof (value) === 'number') return event.newValue === `${value}`;
+      return event.newValue === value;
+    });
   }
 
   /**
@@ -72,8 +75,11 @@ export class AwaitChangeFilterDefinition {
    * @param value A previous value of the attribute that is required to match
    * the trigger.
    */
-  was(value: string | number): WithAttributesDefinition {
-    return this.registerChangeFilter((event) => event.previousValue === `${value}`);
+  was(value: string | number | null | undefined): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (typeof (value) === 'number') return event.previousValue === `${value}`;
+      return event.previousValue === value;
+    });
   }
 
   /**
@@ -91,8 +97,11 @@ export class AwaitChangeFilterDefinition {
    *
    * @param value A value of the attribute that is not allowed to match the trigger.
    */
-  isNot(value: string | number): WithAttributesDefinition {
-    return this.registerChangeFilter((event) => event.newValue !== `${value}`);
+  isNot(value: string | number | null): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (typeof (value) === 'number') return event.newValue !== `${value}`;
+      return event.newValue !== value;
+    });
   }
 
   /**
@@ -111,14 +120,139 @@ export class AwaitChangeFilterDefinition {
    * @param value A previous value of the attribute that is not allowed to match
    * the trigger.
    */
-  wasNot(value: string | number): WithAttributesDefinition {
-    return this.registerChangeFilter((event) => event.previousValue !== `${value}`);
+  wasNot(value: string | number | null | undefined): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (typeof (value) === 'number') return event.previousValue !== `${value}`;
+      return event.previousValue !== value;
+    });
   }
 
-  private registerChangeFilter(matchFunction: HubitatEventMatchFunction): WithAttributesDefinition {
-    const filter = new ChangeFilter(matchFunction);
-    this.addChangeFilter(filter);
-    return new WithAttributesDefinition(this.triggerDefinition);
+  /**
+   * Adds a change filter that accepts only current attribute's value greater
+   * than the one specified.
+   *
+   * @example
+   * ```ts
+   * readonly triggers = [
+   *   HubitatDeviceTrigger.for(119)
+   *     .where('level')
+   *     .wasGreaterThan(15),
+   * ];
+   * ```
+   *
+   * @param value A value of the attribute that is not allowed to match the trigger.
+   */
+  isGreaterThan(value: number): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (event.newValue == null) return false;
+      return Number(event.newValue) > value;
+    });
+  }
+
+  /**
+   * Adds a change filter that accepts only previous attribute's value greater
+   * than the one specified.
+   *
+   * @example
+   * ```ts
+   * readonly triggers = [
+   *   HubitatDeviceTrigger.for(119)
+   *     .where('level')
+   *     .isGreaterThan(15),
+   * ];
+   * ```
+   *
+   * @param value A value of the attribute that is not allowed to match the trigger.
+   */
+  wasGreaterThan(value: number): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (event.previousValue == null) return false;
+      return Number(event.previousValue) > value;
+    });
+  }
+
+  /**
+   * Adds a change filter that accepts only current attribute's value lesser
+   * than the one specified.
+   *
+   * @example
+   * ```ts
+   * readonly triggers = [
+   *   HubitatDeviceTrigger.for(119)
+   *     .where('level')
+   *     .isLesserThan(15),
+   * ];
+   * ```
+   *
+   * @param value A value of the attribute that is not allowed to match the trigger.
+   */
+  isLesserThan(value: number): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (event.newValue == null) return false;
+      return Number(event.newValue) < value;
+    });
+  }
+
+  /**
+   * Adds a change filter that accepts only previous attribute's value lesser
+   * than the one specified.
+   *
+   * @example
+   * ```ts
+   * readonly triggers = [
+   *   HubitatDeviceTrigger.for(119)
+   *     .where('level')
+   *     .wasLesserThan(15),
+   * ];
+   * ```
+   *
+   * @param value A value of the attribute that is not allowed to match the trigger.
+   */
+  wasLesserThan(value: number): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (event.previousValue == null) return false;
+      return Number(event.previousValue) < value;
+    });
+  }
+
+  /**
+   * Adds a change filter that accepts only current attribute's value only when
+   * it increased in comparison to the previous one.
+   *
+   * @example
+   * ```ts
+   * readonly triggers = [
+   *   HubitatDeviceTrigger.for(119)
+   *     .where('level')
+   *     .increased(),
+   * ];
+   * ```
+   */
+  increased(): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (event.newValue == null || event.previousValue == null) return false;
+      return Number(event.previousValue) < Number(event.newValue);
+    });
+  }
+
+  /**
+   * Adds a change filter that accepts only current attribute's value only when
+   * it decreased in comparison to the previous one.
+   *
+   * @example
+   * ```ts
+   * readonly triggers = [
+   *   HubitatDeviceTrigger.for(119)
+   *     .where('level')
+   *     .decreased(),
+   * ];
+   * ```
+   */
+  decreased(): WithAttributesDefinition {
+    return this.registerChangeFilter((event) => {
+      if (event.newValue == null || event.previousValue == null) return false;
+      return Number(event.previousValue) > Number(event.newValue);
+    });
   }
 
   private addChangeFilter(filter: ChangeFilter) {
@@ -131,5 +265,11 @@ export class AwaitChangeFilterDefinition {
       throw new Error(`There are no filter groups in DUTriggerAwaitCF!`);
     }
     lastGroup.filters.push(filter);
+  }
+
+  private registerChangeFilter(matchFunction: HubitatEventMatchFunction): WithAttributesDefinition {
+    const filter = new ChangeFilter(matchFunction);
+    this.addChangeFilter(filter);
+    return new WithAttributesDefinition(this.triggerDefinition);
   }
 }

--- a/src/hubitat-device-events/definition-building/await-change-filter.definition.ts
+++ b/src/hubitat-device-events/definition-building/await-change-filter.definition.ts
@@ -6,6 +6,7 @@
 import { ChangeFilter } from '../trigger-definition/change-filter';
 import { HubitatDeviceTriggerDefinition } from '../trigger-definition/hubitat-device-trigger.definition';
 import { WithAttributesDefinition } from './with-attributes.definition';
+import { HubitatEventMatchFunction } from '../trigger-definition/hubitat-event-match-function.type';
 
 /**
  * An in-progress {@link HubitatDeviceTriggerDefinition} builder class.
@@ -33,7 +34,7 @@ export class AwaitChangeFilterDefinition {
    * ```
    */
   changes(): WithAttributesDefinition {
-    return this.registerChangeFilter('changes');
+    return this.registerChangeFilter(() => true);
   }
 
   /**
@@ -52,7 +53,7 @@ export class AwaitChangeFilterDefinition {
    * @param value A value of the attribute that is required to match the trigger.
    */
   is(value: string | number): WithAttributesDefinition {
-    return this.registerChangeFilter('is', value);
+    return this.registerChangeFilter((event) => event.newValue === `${value}`);
   }
 
   /**
@@ -72,7 +73,7 @@ export class AwaitChangeFilterDefinition {
    * the trigger.
    */
   was(value: string | number): WithAttributesDefinition {
-    return this.registerChangeFilter('was', value);
+    return this.registerChangeFilter((event) => event.previousValue === `${value}`);
   }
 
   /**
@@ -91,7 +92,7 @@ export class AwaitChangeFilterDefinition {
    * @param value A value of the attribute that is not allowed to match the trigger.
    */
   isNot(value: string | number): WithAttributesDefinition {
-    return this.registerChangeFilter('is-not', value);
+    return this.registerChangeFilter((event) => event.newValue !== `${value}`);
   }
 
   /**
@@ -111,13 +112,11 @@ export class AwaitChangeFilterDefinition {
    * the trigger.
    */
   wasNot(value: string | number): WithAttributesDefinition {
-    return this.registerChangeFilter('was-not', value);
+    return this.registerChangeFilter((event) => event.previousValue !== `${value}`);
   }
 
-  private registerChangeFilter(name: string, value?: string | number): WithAttributesDefinition {
-    const filter = new ChangeFilter();
-    filter.name = name;
-    if (value != null) filter.value = value;
+  private registerChangeFilter(matchFunction: HubitatEventMatchFunction): WithAttributesDefinition {
+    const filter = new ChangeFilter(matchFunction);
     this.addChangeFilter(filter);
     return new WithAttributesDefinition(this.triggerDefinition);
   }

--- a/src/hubitat-device-events/definition-building/await-change-filter.definition.ts
+++ b/src/hubitat-device-events/definition-building/await-change-filter.definition.ts
@@ -255,6 +255,15 @@ export class AwaitChangeFilterDefinition {
     });
   }
 
+  /**
+   * Adds a change filter with custom filtering function.
+   * @param filterFunction A function that decides what events is accepted
+   * (`=> true`) and what event is rejected (`=> false`).
+   */
+  customFilter(filterFunction: HubitatEventMatchFunction): WithAttributesDefinition {
+    return this.registerChangeFilter(filterFunction);
+  }
+
   private addChangeFilter(filter: ChangeFilter) {
     const { lastAttribute } = this.triggerDefinition;
     if (lastAttribute == null) {

--- a/src/hubitat-device-events/trigger-definition/attribute-filter.ts
+++ b/src/hubitat-device-events/trigger-definition/attribute-filter.ts
@@ -4,6 +4,8 @@
  */
 
 import { ChangeGroup } from './change-group';
+import { HubitatDeviceEvent } from '../hubitat-device-event';
+import { any } from '../../common/collections-helpers';
 
 /**
  * A class defining the attribute names that are allowed to trigger the event
@@ -36,8 +38,18 @@ export class AttributeFilter {
    * @returns Returns the last group or `undefined` if the
    * {@link AttributeFilter.changeGroups} is an empty array.
    */
-  public get lastGroup(): ChangeGroup | undefined {
+  get lastGroup(): ChangeGroup | undefined {
     if (this.changeGroups.length === 0) return undefined;
     return this.changeGroups[this.changeGroups.length - 1];
+  }
+
+  /**
+   * Verifies if the provided event is matching the requirements of this attribute filter.
+   * @param event An event to match.
+   * @returns Returns a value indicating whether the event is a match.
+   */
+  match(event: HubitatDeviceEvent): boolean {
+    if (!this.attributeNames.includes(event.attributeName)) return false;
+    return any(this.changeGroups, (group) => group.match(event));
   }
 }

--- a/src/hubitat-device-events/trigger-definition/change-filter.spec.ts
+++ b/src/hubitat-device-events/trigger-definition/change-filter.spec.ts
@@ -1,35 +1,17 @@
-import { name as randomName } from 'faker';
-import { doTimes, pickRandom } from '../../common/collections-helpers';
 import { ChangeFilter } from './change-filter';
-
-export function makeChangeFilter(name: string, value?: string | number): ChangeFilter {
-  const filter = new ChangeFilter();
-  filter.name = name;
-  filter.value = value;
-  return filter;
-}
+import { doTimes } from '../../common/collections-helpers';
 
 export function randomChangeFilter(): ChangeFilter {
-  return makeChangeFilter(randomName.findName(), getRandomChangeFilterValue());
+  return new ChangeFilter(() => true);
 }
 
 export function randomChangeFilters(num: number): ChangeFilter[] {
   return doTimes(num, () => randomChangeFilter());
 }
 
-export function getRandomChangeFilterValue(): string | number | undefined {
-  return pickRandom([randomName.findName(), Math.random() * 10000]);
-}
-
-describe('ChangeFilter testing helpers', () => {
-  describe('makeChangeFilter', () => {
-    it('should create a valid filter', () => {
-      doTimes(15, () => {
-        const changeName = randomName.findName();
-        const changeValue = getRandomChangeFilterValue();
-        expect(makeChangeFilter(changeName, changeValue).name).toBe(changeName);
-        expect(makeChangeFilter(changeName, changeValue).value).toBe(changeValue);
-      });
-    });
+describe('ChangeFilter', () => {
+  it('should assign the provided match function', () => {
+    const func = () => true;
+    expect(new ChangeFilter(func).match).toBe(func);
   });
 });

--- a/src/hubitat-device-events/trigger-definition/change-filter.ts
+++ b/src/hubitat-device-events/trigger-definition/change-filter.ts
@@ -3,18 +3,26 @@
  * @module HubitatDeviceEvents
  */
 
+import { HubitatEventMatchFunction } from './hubitat-event-match-function.type';
+
 /**
  * A class representing a configuration af a filter for the attributes value
  * change. Learn more in {@link AttributeFilter} docs.
  */
 export class ChangeFilter {
   /**
-   * A name of the filter to apply.
+   * Verifies if the provided event is matching the requirements of this filter.
+   * @param event An event to match.
+   * @returns Returns a value indicating whether the event is a match.
    */
-  name: string;
+  match: HubitatEventMatchFunction;
 
   /**
-   * A value of the filter to apply. It's existence depends on the filter.
+   * Creates a change filter with provided matching function.
+   * @param matchFunction A function that verifies if provided event is matching
+   * the requirements of this filter.
    */
-  value?: string | number;
+  constructor(matchFunction: HubitatEventMatchFunction) {
+    this.match = matchFunction;
+  }
 }

--- a/src/hubitat-device-events/trigger-definition/change-group.spec.ts
+++ b/src/hubitat-device-events/trigger-definition/change-group.spec.ts
@@ -22,7 +22,7 @@ describe('ChangeGroup testing helpers', () => {
   describe('makeChangeGroup', () => {
     it('should create a valid group', () => {
       doTimes(15, () => {
-        const filters = randomChangeFilters(Math.random() * 5);
+        const filters = randomChangeFilters(randomIntRange(0, 5));
         expect(makeChangeGroup(filters).filters).toBe(filters);
       });
     });

--- a/src/hubitat-device-events/trigger-definition/change-group.ts
+++ b/src/hubitat-device-events/trigger-definition/change-group.ts
@@ -4,6 +4,8 @@
  */
 
 import { ChangeFilter } from './change-filter';
+import { HubitatDeviceEvent } from '../hubitat-device-event';
+import { all } from '../../common/collections-helpers';
 
 /**
  * A group of {@link ChangeFilter change filters} configurations for the
@@ -23,5 +25,15 @@ export class ChangeGroup {
   get lastFilter(): ChangeFilter | undefined {
     if (this.filters.length === 0) return undefined;
     return this.filters[this.filters.length - 1];
+  }
+
+  /**
+   * Verifies if the provided event is matching the requirements of this group.
+   * @param event An event to match.
+   * @returns Returns a value indicating whether the event is a match.
+   */
+  match(event: HubitatDeviceEvent): boolean {
+    if (this.filters.length === 0) return true;
+    return all(this.filters, (filter) => filter.match(event));
   }
 }

--- a/src/hubitat-device-events/trigger-definition/hubitat-device-trigger.definition.ts
+++ b/src/hubitat-device-events/trigger-definition/hubitat-device-trigger.definition.ts
@@ -6,6 +6,8 @@
 import { TriggerDefinition } from '../../automations/trigger-definition';
 import { AttributeFilter } from './attribute-filter';
 import { HUBITAT_DEVICE_EVENT_TYPE } from '../hubitat-device-event-type.const';
+import { HubitatDeviceEvent } from '../hubitat-device-event';
+import { any } from '../../common/collections-helpers';
 
 /**
  * A class defining a hubitat device trigger.
@@ -52,5 +54,21 @@ export class HubitatDeviceTriggerDefinition extends TriggerDefinition {
   get lastAttribute(): AttributeFilter | undefined {
     if (this.attributes.length === 0) return undefined;
     return this.attributes[this.attributes.length - 1];
+  }
+
+  /**
+   * Verifies if the provided event is matching the requirements of this trigger.
+   * @param event An event to match.
+   * @returns Returns a value indicating whether the event is a match.
+   */
+  match(event: HubitatDeviceEvent): boolean {
+    // Filter devices
+    if (this.devices.length > 0 && !this.devices.includes(event.deviceId)) return false;
+    // Filter attributes
+    if (this.attributes.length > 0) {
+      return any(this.attributes, (attribute) => attribute.match(event));
+    }
+    // No filters specified, pass everything
+    return true;
   }
 }

--- a/src/hubitat-device-events/trigger-definition/hubitat-event-match-function.type.ts
+++ b/src/hubitat-device-events/trigger-definition/hubitat-event-match-function.type.ts
@@ -1,0 +1,7 @@
+import { HubitatDeviceEvent } from '../hubitat-device-event';
+
+/**
+ * A function type used to verify if hubitat event matches requirements of a
+ * trigger or it's part.
+ */
+export type HubitatEventMatchFunction = (event: HubitatDeviceEvent) => boolean;


### PR DESCRIPTION
### Added

- Added new event value filters when building Hubitat device event trigger definitions:
  - `isGreaterThan` and `wasGreaterThan` - accepts the event if new/previous value is greater than the one specified.
  - `isLesserThan` and `wasLesserThan` - accepts the event if new/previous value is lesser than the one specified.
  - `increase` and `decrease` - accepts the event if the value increased/decreased.
  - `customFilter` - allows to pass a custom event-matching function to be used.
  - Add tests for filter changes to check if events are properly filtered.