### PR TITLE
Remove need for manual automations registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2020-09-01
+
+### Changed
+
+- Automations do not need manual registration by calling the `automationsService.registerAutomation(...)` anymore.
+
 ## [0.1.1] - 2020-09-01
 
 ### Removed
@@ -100,7 +106,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `common` functions set to mostly simplify interactions with collections and random number generation for
   testing purposes.
 
-[unreleased]: https://github.com/hubhazard/core/compare/v0.1.0-beta.7...HEAD
+[unreleased]: https://github.com/hubhazard/core/compare/v0.1.2...HEAD
+[0.1.1]: https://github.com/hubhazard/core/compare/v0.1.2...v0.1.1
 [0.1.1]: https://github.com/hubhazard/core/compare/v0.1.1...v0.1.1-beta.7
 [0.1.0-beta.7]: https://github.com/hubhazard/core/compare/v0.1.0-beta.6...v0.1.0-beta.7
 [0.1.0-beta.6]: https://github.com/hubhazard/core/compare/v0.1.0-beta.5...v0.1.0-beta.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubhazard/core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A core package for HubHazard server.",
   "author": "Beniamin Dudek <online.xkonti@gmail.com>",
   "license": "MIT",

--- a/src/automations/automation.ts
+++ b/src/automations/automation.ts
@@ -3,10 +3,11 @@
  * @module Automations
  */
 
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { AutomationEvent } from './automation-event';
 import { BuildableToTriggerDefinition } from './buildable-to-trigger-definition';
 import { TriggerDefinition } from './trigger-definition';
+import { AutomationsService } from './automations.service';
 
 /**
  * A base class for all automations. Allows for automations to be correctly
@@ -32,10 +33,26 @@ export abstract class Automation {
   abstract readonly triggers: BuildableToTriggerDefinition[];
 
   /**
+   * A reference to automations service injected by the Nest.js Dependency
+   * Injection. Its value is not available in the constructor.
+   * @protected
+   */
+  @Inject()
+  protected readonly automationsService: AutomationsService;
+
+  /**
    * A cache for `get builtTriggers`.
    * @private
    */
   private builtTriggersCache: TriggerDefinition[] | undefined = undefined;
+
+  /**
+   * A default constructor that registers this automation to the automations
+   * service.
+   */
+  public constructor() {
+    setTimeout(() => this.automationsService.registerAutomation(this), 1000);
+  }
 
   /**
    * Returns a list of triggers already built as {@link TriggerDefinition}.


### PR DESCRIPTION
Related to #21 


### Changed

- Automations do not need manual registration by calling the `automationsService.registerAutomation(...)` anymore.