### PR TITLE
Implement DoorControl, GarageDoorControl, Valve, WindowShade capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3] - 2020-09-07
+## 0.1.4 - 2020-09-13
+
+### Added
+
+- Added support for [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl) and
+  [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl) capabilities by
+  adding functions:
+  - `close`
+  - `getDoorPosition`
+  - `isClosed`
+  - `open`
+  - `setPosition`
+- Added support for [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve) capability by adding
+  functions:
+  - `close`
+  - `getValvePosition`
+  - `isClosed`
+  - `open`
+  - `setPosition`
+- Added support for [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+  capability by adding functions:
+  - `close`
+  - `getWindowShadeCoverage`
+  - `getWindowShadePosition`
+  - `isClosed`
+  - `open`
+  - `setPosition`
+  - `setWindowShadeCoverage`
+- Added support for [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
+  capability in virtual devices by adding functions:
+  - `close`
+  - `open`
+- Added support for [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl),
+  [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl),
+  [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve),
+  [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade) capabilities in `isOpen`
+  function.
+- Added capability-related types:
+  - `EDoorStatus`
+  - `EWindowShadePosition`
+
+### Changed
+
+- Renamed `EOpenStatus` type to `EOpenClosedPosition` for greater compatibility with other capabilities.
+
+## 0.1.3 - 2020-09-07
 
 ### Added
 
@@ -73,19 +118,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `toggleRelaySwitch` - use `toggle`
     - `toggleSwitch` - use `toggle`
 
-## [0.1.2] - 2020-09-01
+## 0.1.2 - 2020-09-01
 
 ### Changed
 
 - Automations do not need manual registration by calling the `automationsService.registerAutomation(...)` anymore.
 
-## [0.1.1] - 2020-09-01
+## 0.1.1 - 2020-09-01
 
 ### Removed
 
 - Move guides in README.md to the wiki
 
-## [0.1.0-beta.7] - 2020-08-29
+## 0.1.0-beta.7 - 2020-08-29
 
 ### Added
 
@@ -95,7 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `increase` and `decrease` - accepts the event if the value increased/decreased.
   - `customFilter` - allows to pass a custom event-matching function to be used.
 
-## [0.1.0-beta.6] - 2020-08-27
+## 0.1.0-beta.6 - 2020-08-27
 
 ### Added
 
@@ -117,7 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added capability-related helper function `enumListToStringList`.
 - Added `isHubitatDeviceEvent` and `isTimerEvent` functions for easier checking events and triggers types.
 
-## [0.1.0-beta.5] - 2020-08-26
+## 0.1.0-beta.5 - 2020-08-26
 
 ### Added
 
@@ -129,13 +174,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation links now direct to the project wiki
 - Roadmap section now leads to a list of issues with a `task` label
 
-## [0.1.0-beta.4] - 2020-08-25
+## 0.1.0-beta.4 - 2020-08-25
 
 ### Added
 
 - Completed the documentation of all source code. [ #7 ]
 
-## [0.1.0-beta.3] - 2020-08-23
+## 0.1.0-beta.3 - 2020-08-23
 
 ### Added
 
@@ -146,7 +191,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed unused functions from `number-helpers`. [ #2 ]
 
-## [0.1.0-beta.1] - 2020-08-21
+## 0.1.0-beta.1 - 2020-08-21
 
 ### Added
 
@@ -161,14 +206,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [capability-based](https://docs.hubitat.com/index.php?title=Driver_Capability_List) manner.
 - Added `common` functions set to mostly simplify interactions with collections and random number generation for
   testing purposes.
-
-[unreleased]: https://github.com/hubhazard/core/compare/v0.1.3...HEAD
-[0.1.3]: https://github.com/hubhazard/core/compare/v0.1.3...v0.1.2
-[0.1.2]: https://github.com/hubhazard/core/compare/v0.1.2...v0.1.1
-[0.1.1]: https://github.com/hubhazard/core/compare/v0.1.1...v0.1.1-beta.7
-[0.1.0-beta.7]: https://github.com/hubhazard/core/compare/v0.1.0-beta.6...v0.1.0-beta.7
-[0.1.0-beta.6]: https://github.com/hubhazard/core/compare/v0.1.0-beta.5...v0.1.0-beta.6
-[0.1.0-beta.5]: https://github.com/hubhazard/core/compare/v0.1.0-beta.4...v0.1.0-beta.5
-[0.1.0-beta.4]: https://github.com/hubhazard/core/compare/v0.1.0-beta.3...v0.1.0-beta.4
-[0.1.0-beta.3]: https://github.com/hubhazard/core/compare/v0.1.0-beta.1...v0.1.0-beta.3
-[0.1.0-beta.1]: https://github.com/hubhazard/core/releases/tag/v0.1.0-beta.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hubhazard/core",
-  "version": "0.1.3",
-  "description": "A core package for HubHazard server.",
+  "version": "0.1.4",
+  "description": "A core package for HubHazard server with built-in Hubitat Elevation support.",
   "author": "Beniamin Dudek <online.xkonti@gmail.com>",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/src/hubitat-capabilities/functions/close.function.ts
+++ b/src/hubitat-capabilities/functions/close.function.ts
@@ -1,0 +1,50 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
+import { getDevice } from '..';
+
+/**
+ * Closes the device.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param device A target device.
+ */
+export async function close(device: HubitatDevice): Promise<void>;
+
+/**
+ * Closes the device.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param deviceId An ID of the target device.
+ */
+export async function close(deviceId: number): Promise<void>;
+
+/**
+ * Closes the device.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param deviceOrId An ID of the target device or the device itself.
+ */
+export async function close(deviceOrId: HubitatDevice | number): Promise<void>;
+
+export async function close(deviceOrId: HubitatDevice | number): Promise<void> {
+  await getDevice(deviceOrId).sendCommand('open');
+}

--- a/src/hubitat-capabilities/functions/close.function.ts
+++ b/src/hubitat-capabilities/functions/close.function.ts
@@ -10,6 +10,7 @@ import { getDevice } from '..';
  * Closes the device.
  *
  * Capabilities:
+ * - Virtual [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
  * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
  * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
@@ -23,6 +24,7 @@ export async function close(device: HubitatDevice): Promise<void>;
  * Closes the device.
  *
  * Capabilities:
+ * - Virtual [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
  * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
  * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
@@ -36,6 +38,7 @@ export async function close(deviceId: number): Promise<void>;
  * Closes the device.
  *
  * Capabilities:
+ * - Virtual [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
  * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
  * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
@@ -46,5 +49,9 @@ export async function close(deviceId: number): Promise<void>;
 export async function close(deviceOrId: HubitatDevice | number): Promise<void>;
 
 export async function close(deviceOrId: HubitatDevice | number): Promise<void> {
-  await getDevice(deviceOrId).sendCommand('open');
+  const device = getDevice(deviceOrId);
+  const command = 'close';
+  if (!device.hasCommand(command))
+    throw new Error(`The device '${device.name}' doesn't support the '${command}' command.`);
+  await device.sendCommand(command);
 }

--- a/src/hubitat-capabilities/functions/get-contact-sensor-status.function.ts
+++ b/src/hubitat-capabilities/functions/get-contact-sensor-status.function.ts
@@ -4,38 +4,38 @@
  */
 
 import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
-import { EOpenStatus, getDevice } from '..';
+import { EOpenClosedPosition, getDevice } from '..';
 
 /**
  * Returns current contact sensor status.
  *
  * Capabilities:
- * - ContactSensor
+ * - [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  *
  * @param device A target device.
  * @param defaultValue A value returned in case getting the device status has
  * failed.
  * @returns A status of the contact sensor or the default value.
  */
-export function getContactSensorStatus(device: HubitatDevice, defaultValue: EOpenStatus): EOpenStatus;
+export function getContactSensorStatus(device: HubitatDevice, defaultValue: EOpenClosedPosition): EOpenClosedPosition;
 
 /**
  * Returns current contact sensor status.
  *
  * Capabilities:
- * - ContactSensor
+ * - [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  *
  * @param deviceId An ID of the target device.
  * @param defaultValue A value returned in case getting the device status has
  * failed.
  * @returns A status of the contact sensor or the default value.
  */
-export function getContactSensorStatus(deviceId: number, defaultValue: EOpenStatus): EOpenStatus;
+export function getContactSensorStatus(deviceId: number, defaultValue: EOpenClosedPosition): EOpenClosedPosition;
 
 export function getContactSensorStatus(
   deviceOrId: HubitatDevice | number,
-  defaultValue: EOpenStatus = 'closed',
-): EOpenStatus {
+  defaultValue: EOpenClosedPosition = 'closed',
+): EOpenClosedPosition {
   const contact = getDevice(deviceOrId).getAttributeAsString('contact');
   if (contact === 'closed' || contact === 'open') return contact;
   return defaultValue;

--- a/src/hubitat-capabilities/functions/get-door-position.function.ts
+++ b/src/hubitat-capabilities/functions/get-door-position.function.ts
@@ -1,0 +1,35 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
+import { EDoorStatus, getDevice } from '..';
+
+/**
+ * Returns current door position.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ *
+ * @param device A target device.
+ * @returns Returns current door position.
+ */
+export function getDoorPosition(device: HubitatDevice): EDoorStatus;
+
+/**
+ * Returns current door position.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns current door position.
+ */
+export function getDoorPosition(deviceId: number): EDoorStatus;
+
+export function getDoorPosition(deviceOrId: HubitatDevice | number): EDoorStatus {
+  return getDevice(deviceOrId).getAttributeAsString('door') as EDoorStatus;
+}

--- a/src/hubitat-capabilities/functions/get-valve-position.function.ts
+++ b/src/hubitat-capabilities/functions/get-valve-position.function.ts
@@ -1,0 +1,33 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
+import { EOpenClosedPosition, getDevice } from '..';
+
+/**
+ * Returns current valve position.
+ *
+ * Capabilities:
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ *
+ * @param device A target device.
+ * @returns Returns current valve position.
+ */
+export function getValvePosition(device: HubitatDevice): EOpenClosedPosition;
+
+/**
+ * Returns current valve position.
+ *
+ * Capabilities:
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns current valve position.
+ */
+export function getValvePosition(deviceId: number): EOpenClosedPosition;
+
+export function getValvePosition(deviceOrId: HubitatDevice | number): EOpenClosedPosition {
+  return getDevice(deviceOrId).getAttributeAsString('valve') as EOpenClosedPosition;
+}

--- a/src/hubitat-capabilities/functions/get-window-shade-coverage.function.ts
+++ b/src/hubitat-capabilities/functions/get-window-shade-coverage.function.ts
@@ -1,0 +1,33 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
+import { getDevice } from '..';
+
+/**
+ * Returns current window shade position. 0 is closed, 100 is open.
+ *
+ * Capabilities:
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param device A target device.
+ * @returns Returns current window shade position. 0 is closed, 100 is open.
+ */
+export function getWindowShadeCoverage(device: HubitatDevice): number;
+
+/**
+ * Returns current window shade position. 0 is closed, 100 is open.
+ *
+ * Capabilities:
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns current window shade position. 0 is closed, 100 is open.
+ */
+export function getWindowShadeCoverage(deviceId: number): number;
+
+export function getWindowShadeCoverage(deviceOrId: HubitatDevice | number): number {
+  return getDevice(deviceOrId).getAttributeAsFloat('position');
+}

--- a/src/hubitat-capabilities/functions/get-window-shade-position.function.ts
+++ b/src/hubitat-capabilities/functions/get-window-shade-position.function.ts
@@ -1,0 +1,33 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
+import { EWindowShadePosition, getDevice } from '..';
+
+/**
+ * Returns current valve position.
+ *
+ * Capabilities:
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param device A target device.
+ * @returns Returns current valve position.
+ */
+export function getWindowShadePosition(device: HubitatDevice): EWindowShadePosition;
+
+/**
+ * Returns current valve position.
+ *
+ * Capabilities:
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param deviceId An ID of the target device.
+ * @returns Returns current valve position.
+ */
+export function getWindowShadePosition(deviceId: number): EWindowShadePosition;
+
+export function getWindowShadePosition(deviceOrId: HubitatDevice | number): EWindowShadePosition {
+  return getDevice(deviceOrId).getAttributeAsString('windowShade') as EWindowShadePosition;
+}

--- a/src/hubitat-capabilities/functions/is-closed.function.ts
+++ b/src/hubitat-capabilities/functions/is-closed.function.ts
@@ -8,7 +8,7 @@ import { ECapability } from '../../hubitat-device-events/capability.enum';
 import { getContactSensorStatus, getDevice, getDoorPosition, getValvePosition, getWindowShadePosition } from '..';
 
 /**
- * Returns a value whether the device is open.
+ * Returns a value whether the device is closed.
  *
  * Capabilities:
  * - [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
@@ -18,13 +18,13 @@ import { getContactSensorStatus, getDevice, getDoorPosition, getValvePosition, g
  * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
  *
  * @param device A target device.
- * @returns `true` if the device is open; `false` if sensor is closed or
+ * @returns `true` if the device is closed; `false` if sensor is open or
  * encountered an error.
  */
-export function isOpen(device: HubitatDevice): boolean;
+export function isClosed(device: HubitatDevice): boolean;
 
 /**
- * Returns a value whether the device is open.
+ * Returns a value whether the device is closed.
  *
  * Capabilities:
  * - [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
@@ -36,12 +36,12 @@ export function isOpen(device: HubitatDevice): boolean;
  * @param device A target device.
  * @param defaultValue A value returned in case getting the device status has
  * failed.
- * @returns `true` if the device is open; `false` if sensor is closed.
+ * @returns `true` if the device is closed; `false` if sensor is open.
  */
-export function isOpen(device: HubitatDevice, defaultValue: boolean): boolean;
+export function isClosed(device: HubitatDevice, defaultValue: boolean): boolean;
 
 /**
- * Returns a value whether the device is open.
+ * Returns a value whether the device is closed.
  *
  * Capabilities:
  * - [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
@@ -51,12 +51,12 @@ export function isOpen(device: HubitatDevice, defaultValue: boolean): boolean;
  * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
  *
  * @param deviceId An ID of the target device.
- * @returns `true` if the device is open; `false` if sensor is closed.
+ * @returns `true` if the device is closed; `false` if sensor is open.
  */
-export function isOpen(deviceId: number): boolean;
+export function isClosed(deviceId: number): boolean;
 
 /**
- * Returns a value whether the device is open.
+ * Returns a value whether the device is closed.
  *
  * Capabilities:
  * - [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
@@ -68,32 +68,32 @@ export function isOpen(deviceId: number): boolean;
  * @param deviceId An ID of the target device.
  * @param defaultValue A value returned in case getting the device status has
  * failed.
- * @returns `true` if the device is open; `false` if sensor is closed or
+ * @returns `true` if the device is closed; `false` if sensor is open or
  * encountered an error.
  */
-export function isOpen(deviceId: number, defaultValue: boolean): boolean;
+export function isClosed(deviceId: number, defaultValue: boolean): boolean;
 
-export function isOpen(deviceOrId: HubitatDevice | number, defaultValue = false): boolean {
+export function isClosed(deviceOrId: HubitatDevice | number, defaultValue = false): boolean {
   const device = getDevice(deviceOrId);
 
   if (device.hasCapability(ECapability.ContactSensor)) {
     const status = getContactSensorStatus(device, defaultValue ? 'open' : 'closed');
-    return status === 'open';
+    return status === 'closed';
   }
 
   if (device.hasCapability(ECapability.DoorControl) || device.hasCapability(ECapability.GarageDoorControl)) {
     const status = getDoorPosition(device);
-    return status === 'open';
+    return status === 'closed';
   }
 
   if (device.hasCapability(ECapability.Valve)) {
     const status = getValvePosition(device);
-    return status === 'open';
+    return status === 'closed';
   }
 
   if (device.hasCapability(ECapability.WindowShade)) {
     const status = getWindowShadePosition(device);
-    return status === 'open' || status === 'partially open';
+    return status === 'closed';
   }
 
   return defaultValue;

--- a/src/hubitat-capabilities/functions/open.function.ts
+++ b/src/hubitat-capabilities/functions/open.function.ts
@@ -10,6 +10,7 @@ import { getDevice } from '..';
  * Opens the device.
  *
  * Capabilities:
+ * - Virtual [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
  * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
  * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
@@ -23,6 +24,7 @@ export async function open(device: HubitatDevice): Promise<void>;
  * Opens the device.
  *
  * Capabilities:
+ * - Virtual [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
  * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
  * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
@@ -36,6 +38,7 @@ export async function open(deviceId: number): Promise<void>;
  * Opens the device.
  *
  * Capabilities:
+ * - Virtual [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
  * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
  * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
@@ -46,5 +49,9 @@ export async function open(deviceId: number): Promise<void>;
 export async function open(deviceOrId: HubitatDevice | number): Promise<void>;
 
 export async function open(deviceOrId: HubitatDevice | number): Promise<void> {
-  await getDevice(deviceOrId).sendCommand('open');
+  const device = getDevice(deviceOrId);
+  const command = 'open';
+  if (!device.hasCommand(command))
+    throw new Error(`The device '${device.name}' doesn't support the '${command}' command.`);
+  await device.sendCommand(command);
 }

--- a/src/hubitat-capabilities/functions/open.function.ts
+++ b/src/hubitat-capabilities/functions/open.function.ts
@@ -1,0 +1,50 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
+import { getDevice } from '..';
+
+/**
+ * Opens the device.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param device A target device.
+ */
+export async function open(device: HubitatDevice): Promise<void>;
+
+/**
+ * Opens the device.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param deviceId An ID of the target device.
+ */
+export async function open(deviceId: number): Promise<void>;
+
+/**
+ * Opens the device.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param deviceOrId An ID of the target device or the device itself.
+ */
+export async function open(deviceOrId: HubitatDevice | number): Promise<void>;
+
+export async function open(deviceOrId: HubitatDevice | number): Promise<void> {
+  await getDevice(deviceOrId).sendCommand('open');
+}

--- a/src/hubitat-capabilities/functions/set-position.function.ts
+++ b/src/hubitat-capabilities/functions/set-position.function.ts
@@ -1,0 +1,40 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
+import { close, EOpenClosedPosition, open } from '..';
+
+/**
+ * Moves the device to provided position.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param device A target device.
+ * @param position The position to initialize.
+ */
+export async function setPosition(device: HubitatDevice, position: EOpenClosedPosition): Promise<void>;
+
+/**
+ * Moves the device to provided position.
+ *
+ * Capabilities:
+ * - [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl)
+ * - [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl)
+ * - [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve)
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param deviceId An ID of the target device.
+ * @param position The position to initialize.
+ */
+export async function setPosition(deviceId: number, position: EOpenClosedPosition): Promise<void>;
+
+export async function setPosition(deviceOrId: HubitatDevice | number, position: EOpenClosedPosition): Promise<void> {
+  if (position === 'open') await open(deviceOrId);
+  else close(deviceOrId);
+}

--- a/src/hubitat-capabilities/functions/set-window-shade-coverage.function.ts
+++ b/src/hubitat-capabilities/functions/set-window-shade-coverage.function.ts
@@ -1,0 +1,37 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+import { HubitatDevice } from '../../hubitat-device-events/hubitat-device';
+import { getDevice } from '..';
+
+/**
+ * Sets the percentage coverage of the window shade.
+ *
+ * Capabilities:
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param device A target device.
+ * @param coverage A coverage percentage to set.
+ */
+export async function setWindowShadeCoverage(device: HubitatDevice, coverage: number): Promise<void>;
+
+/**
+ * Sets the percentage coverage of the window shade.
+ *
+ * Capabilities:
+ * - [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
+ *
+ * @param deviceId An ID of the target device.
+ * @param coverage A coverage percentage to set.
+ */
+export async function setWindowShadeCoverage(deviceId: number, coverage: number): Promise<void>;
+
+export async function setWindowShadeCoverage(deviceOrId: HubitatDevice | number, coverage: number): Promise<void> {
+  const command = 'setPosition';
+  const device = getDevice(deviceOrId);
+  if (!device.hasCommand(command))
+    throw new Error(`The device '${device.name}' doesn't support the '${command}' command.`);
+  await device.sendCommand(command, coverage);
+}

--- a/src/hubitat-capabilities/index.ts
+++ b/src/hubitat-capabilities/index.ts
@@ -13,12 +13,15 @@
 
 /* FUNCTIONS */
 
+export * from './functions/close.function';
+
 export * from './functions/get-alarm-setting.function';
 export * from './functions/get-battery-status.function';
 export * from './functions/get-carbon-dioxide.function';
 export * from './functions/get-carbon-monoxide.function';
 export * from './functions/get-contact-sensor-status.function';
 export * from './functions/get-cooling-setpoint.function';
+export * from './functions/get-door-position.function';
 export * from './functions/get-heating-setpoint.function';
 export * from './functions/get-illuminance.function';
 export * from './functions/get-level.function';
@@ -32,14 +35,19 @@ export * from './functions/get-thermostat-mode.function';
 export * from './functions/get-thermostat-operating-state.function';
 export * from './functions/get-thermostat-schedule.function';
 export * from './functions/get-thermostat-setpoint.function';
+export * from './functions/get-valve-position.function';
+export * from './functions/get-window-shade-coverage.function';
+export * from './functions/get-window-shade-position.function';
 
 export * from './functions/is-accelerating';
 export * from './functions/is-any-on.function';
+export * from './functions/is-closed.function';
 export * from './functions/is-motion-detected.function';
 export * from './functions/is-on.function';
 export * from './functions/is-open.function';
 export * from './functions/is-present.function';
 
+export * from './functions/open.function';
 export * from './functions/refresh.function';
 
 export * from './functions/set-acceleration.function';
@@ -47,6 +55,7 @@ export * from './functions/set-alarm-setting.function';
 export * from './functions/set-cooling-setpoint.function';
 export * from './functions/set-heating-setpoint.function';
 export * from './functions/set-level.funciton';
+export * from './functions/set-position.function';
 export * from './functions/set-supported-thermostat-fan-modes.function';
 export * from './functions/set-supported-thermostat-modes.function';
 export * from './functions/set-switch.function';
@@ -56,6 +65,7 @@ export * from './functions/set-thermostat-mode.function';
 export * from './functions/set-thermostat-operating-state.function';
 export * from './functions/set-thermostat-schedule.function';
 export * from './functions/set-thermostat-setpoint.function';
+export * from './functions/set-window-shade-coverage.function';
 
 export * from './functions/start-level-change.function';
 export * from './functions/stop-level-change.function';
@@ -79,9 +89,11 @@ export * from './helpers/get-device.function';
 
 export * from './types/active-status.type';
 export * from './types/alarm-setting.type';
+export * from './types/door-status.type';
 export * from './types/level-change-direction.type';
-export * from './types/open-status.type';
+export * from './types/open-closed-position.type';
 export * from './types/switch-status.type';
 export * from './types/thermostat-fan-modes.type';
 export * from './types/thermostat-modes.type';
 export * from './types/thermostat-operating-modes.type';
+export * from './types/window-shade-position.type';

--- a/src/hubitat-capabilities/types/door-status.type.ts
+++ b/src/hubitat-capabilities/types/door-status.type.ts
@@ -1,0 +1,9 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+/**
+ * All possible statuses of a door.
+ */
+export type EDoorStatus = 'closed' | 'closing' | 'open' | 'opening' | 'unknown';

--- a/src/hubitat-capabilities/types/open-closed-position.type.ts
+++ b/src/hubitat-capabilities/types/open-closed-position.type.ts
@@ -1,0 +1,9 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+/**
+ * Positions: `open` and `closed`.
+ */
+export type EOpenClosedPosition = 'closed' | 'open';

--- a/src/hubitat-capabilities/types/open-status.type.ts
+++ b/src/hubitat-capabilities/types/open-status.type.ts
@@ -1,9 +1,0 @@
-/**
- * @packageDocumentation
- * @module HubitatCapabilities
- */
-
-/**
- * Possible open-closed status.
- */
-export type EOpenStatus = 'closed' | 'open';

--- a/src/hubitat-capabilities/types/window-shade-position.type.ts
+++ b/src/hubitat-capabilities/types/window-shade-position.type.ts
@@ -1,0 +1,9 @@
+/**
+ * @packageDocumentation
+ * @module HubitatCapabilities
+ */
+
+/**
+ * All possible positions of the window shade.
+ */
+export type EWindowShadePosition = 'closed' | 'closing' | 'open' | 'opening' | 'partially open' | 'unknown';


### PR DESCRIPTION
Closes #35
Closes #40

### Added

- Added support for [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl) and
  [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl) capabilities by
  adding functions:
  - `close`
  - `getDoorPosition`
  - `isClosed`
  - `open`
  - `setPosition`
- Added support for [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve) capability by adding
  functions:
  - `close`
  - `getValvePosition`
  - `isClosed`
  - `open`
  - `setPosition`
- Added support for [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade)
  capability by adding functions:
  - `close`
  - `getWindowShadeCoverage`
  - `getWindowShadePosition`
  - `isClosed`
  - `open`
  - `setPosition`
  - `setWindowShadeCoverage`
- Added support for [ContactSensor](https://docs.hubitat.com/index.php?title=Driver_Capability_List#ContactSensor)
  capability in virtual devices by adding functions:
  - `close`
  - `open`
- Added support for [DoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#DoorControl),
  [GarageDoorControl](https://docs.hubitat.com/index.php?title=Driver_Capability_List#GarageDoorControl),
  [Valve](https://docs.hubitat.com/index.php?title=Driver_Capability_List#Valve),
  [WindowShade](https://docs.hubitat.com/index.php?title=Driver_Capability_List#WindowShade) capabilities in `isOpen`
  function.
- Added capability-related types:
  - `EDoorStatus`
  - `EWindowShadePosition`

### Changed

- Renamed `EOpenStatus` type to `EOpenClosedPosition` for greater compatibility with other capabilities.